### PR TITLE
Fix multipart detection logic in FormHttpMessageConverter

### DIFF
--- a/spring-android-rest-template/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
@@ -212,7 +212,7 @@ public class FormHttpMessageConverter implements HttpMessageConverter<MultiValue
 
 	private boolean isMultipart(MultiValueMap<String, ?> map, MediaType contentType) {
 		if (contentType != null) {
-			return MediaType.MULTIPART_FORM_DATA.equals(contentType);
+			return MediaType.MULTIPART_FORM_DATA.includes(contentType);
 		}
 		for (String name : map.keySet()) {
 			for (Object value : map.get(name)) {


### PR DESCRIPTION
isMultipart(map, contentType) incorrectly returns false for
contentType="multipart/form-data; charset=utf-8", should return true.
