### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ As **Project**, please select **Spring for Android**. The **Project Lead** is **
 
 1. go to [https://github.com/spring-projects/spring-android](https://github.com/spring-projects/spring-android)
 2. hit the "fork" button and choose your own github account as the target
-3. for more detail see [http://help.github.com/fork-a-repo/](http://help.github.com/fork-a-repo/)
+3. for more detail see [https://help.github.com/fork-a-repo/](https://help.github.com/fork-a-repo/)
 
 ## Setup your Local Development Environment
 
@@ -44,7 +44,7 @@ _you should see branches on origin as well as upstream, including 'master'_
 * When ready to resolve an issue or to collaborate with others, you can push your branch to origin (your fork), e.g.: `git push origin ANDROID-123`
 * If you want to collaborate with another contributor, have them fork your repository (add it as a remote) and `git fetch <your-username>` to grab your branch. Alternatively, they can use `git fetch --all` to sync their local state with all of their remotes.
 * If you grant that collaborator push access to your repository, they can even apply their changes to your branch.
-* When ready for your contribution to be reviewed for potential inclusion in the master branch of the canonical spring-android repository (what you know as 'upstream'), issue a pull request to the Spring repository (for more detail, see [http://help.github.com/send-pull-requests/](http://help.github.com/send-pull-requests/)).
+* When ready for your contribution to be reviewed for potential inclusion in the master branch of the canonical spring-android repository (what you know as 'upstream'), issue a pull request to the Spring repository (for more detail, see [https://help.github.com/send-pull-requests/](https://help.github.com/send-pull-requests/)).
 * The project lead may merge your changes into the upstream master branch as-is, he may keep the pull request open yet add a comment about something that should be modified, or he might reject the pull request by closing it.
 * A prerequisite for any pull request is that it will be cleanly merge-able with the upstream master's current state. **This is the responsibility of any contributor.** If your pull request cannot be applied cleanly, the project lead will most likely add a comment requesting that you make it merge-able.
 

--- a/README.md
+++ b/README.md
@@ -250,34 +250,34 @@ Follow [@SpringCentral] as well as [@SpringAndroid] on Twitter. In-depth article
 [Spring for Android] is released under version 2.0 of the [Apache License].
 
 
-[Spring for Android]: http://www.spring.io/projects/spring-android
-[Spring Framework]: http://www.spring.io/projects/spring-framework
+[Spring for Android]: https://www.spring.io/projects/spring-android
+[Spring Framework]: https://www.spring.io/projects/spring-framework
 [Android Build System]: http://tools.android.com/tech-docs/new-build-system/user-guide
-[Android]: http://developer.android.com
-[Gradle]: http://www.gradle.org
-[Android Maven Plugin]: http://code.google.com/p/maven-android-plugin
-[Maven]: http://maven.apache.org
+[Android]: https://developer.android.com
+[Gradle]: https://www.gradle.org
+[Android Maven Plugin]: https://code.google.com/p/maven-android-plugin
+[Maven]: https://maven.apache.org
 [downloading Spring artifacts]: https://github.com/spring-projects/spring-framework/wiki/Downloading-Spring-artifacts
 [building a distribution with dependencies]: https://github.com/spring-projects/spring-framework/wiki/Building-a-distribution-with-dependencies
-[Javadoc]: http://docs.spring.io/spring-android/docs/current/api/
-[reference docs]: http://docs.spring.io/spring-android/docs/current/reference/html/
+[Javadoc]: https://docs.spring.io/spring-android/docs/current/api/
+[reference docs]: https://docs.spring.io/spring-android/docs/current/reference/html/
 [samples repository]: https://github.com/spring-projects/spring-android-samples
-[spring.io]: http://spring.io
-[guides]: http://spring.io/guides
-[spring-android tag]: http://stackoverflow.com/questions/tagged/spring-android
-[Stack Overflow]: http://stackoverflow.com/faq
-[Commercial support]: http://spring.io/services
-[Spring Android JIRA]: http://jira.spring.io/browse/ANDROID
-[Git]: http://git-scm.com
-[GitHub for Windows]: http://windows.github.com
-[GitHub for Mac]: http://mac.github.com
+[spring.io]: https://spring.io
+[guides]: https://spring.io/guides
+[spring-android tag]: https://stackoverflow.com/questions/tagged/spring-android
+[Stack Overflow]: https://stackoverflow.com/faq
+[Commercial support]: https://spring.io/services
+[Spring Android JIRA]: https://jira.spring.io/browse/ANDROID
+[Git]: https://git-scm.com
+[GitHub for Windows]: https://windows.github.com
+[GitHub for Mac]: https://mac.github.com
 [GitHub issues]: https://github.com/spring-projects/spring-android/issues?direction=desc&sort=created&state=open
 [the lifecycle of an issue]: https://github.com/spring-projects/spring-framework/wiki/The-Lifecycle-of-an-Issue
-[sts]: http://www.spring.io/sts
-[Pull requests]: http://help.github.com/send-pull-requests
+[sts]: https://www.spring.io/sts
+[Pull requests]: https://help.github.com/send-pull-requests
 [contributor guidelines]: CONTRIBUTING.md
 [@SpringCentral]: https://twitter.com/springcentral
 [@SpringAndroid]: https://twitter.com/springandroid
-[The Spring Blog]: http://spring.io/blog/
-[news feed]: http://spring.io/blog/category/news
+[The Spring Blog]: https://spring.io/blog/
+[news feed]: https://spring.io/blog/category/news
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0

--- a/spring-android-core/src/main/java/org/springframework/core/BridgeMethodResolver.java
+++ b/spring-android-core/src/main/java/org/springframework/core/BridgeMethodResolver.java
@@ -39,7 +39,7 @@ import org.springframework.util.ReflectionUtils;
  * When attempting to locate annotations on {@link Method Methods}, it is wise to check
  * for bridge {@link Method Methods} as appropriate and find the bridged {@link Method}.
  *
- * <p>See <a href="http://java.sun.com/docs/books/jls/third_edition/html/expressions.html#15.12.4.5">
+ * <p>See <a href="https://java.sun.com/docs/books/jls/third_edition/html/expressions.html#15.12.4.5">
  * The Java Language Specification</a> for more details on the use of bridge methods.
  *
  * @author Rob Harrop
@@ -213,8 +213,8 @@ public abstract class BridgeMethodResolver {
 	/**
 	 * Compare the signatures of the bridge method and the method which it bridges. If
 	 * the parameter and return types are the same, it is a 'visibility' bridge method
-	 * introduced in Java 6 to fix http://bugs.sun.com/view_bug.do?bug_id=6342411.
-	 * See also http://stas-blogspot.blogspot.com/2010/03/java-bridge-methods-explained.html
+	 * introduced in Java 6 to fix https://bugs.java.com/view_bug.do?bug_id=6342411.
+	 * See also https://stas-blogspot.blogspot.com/2010/03/java-bridge-methods-explained.html
 	 * @return whether signatures match as described
 	 */
 	public static boolean isVisibilityBridgeMethodPair(Method bridgeMethod, Method bridgedMethod) {

--- a/spring-android-core/src/main/java/org/springframework/core/ParameterizedTypeReference.java
+++ b/spring-android-core/src/main/java/org/springframework/core/ParameterizedTypeReference.java
@@ -37,7 +37,7 @@ import java.lang.reflect.Type;
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
  * @since 2.0
- * @see <a href="http://gafter.blogspot.nl/2006/12/super-type-tokens.html">Neal Gafter on Super Type Tokens</a>
+ * @see <a href="https://gafter.blogspot.nl/2006/12/super-type-tokens.html">Neal Gafter on Super Type Tokens</a>
  */
 public abstract class ParameterizedTypeReference<T> {
 

--- a/spring-android-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-android-core/src/main/java/org/springframework/util/StringUtils.java
@@ -34,7 +34,7 @@ import java.util.TreeSet;
  * Miscellaneous {@link String} utility methods.
  *
  * <p>Mainly for internal use within the framework; consider
- * <a href="http://jakarta.apache.org/commons/lang/">Jakarta's Commons Lang</a>
+ * <a href="https://jakarta.apache.org/commons/lang/">Jakarta's Commons Lang</a>
  * for a more comprehensive suite of String utilities.
  *
  * <p>This class delivers some simple functionality that should really

--- a/spring-android-rest-template/src/main/java/org/springframework/http/ContentCodingType.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/ContentCodingType.java
@@ -169,7 +169,7 @@ public class ContentCodingType implements Comparable<ContentCodingType> {
 	/**
 	 * Checks the given token string for illegal characters, as defined in RFC 2616, section 2.2.
 	 * @throws IllegalArgumentException in case of illegal characters
-	 * @see <a href="http://tools.ietf.org/html/rfc2616#section-2.2">HTTP 1.1, section 2.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2616#section-2.2">HTTP 1.1, section 2.2</a>
 	 */
 	private void checkToken(String s) {
 		for (int i = 0; i < s.length(); i++) {

--- a/spring-android-rest-template/src/main/java/org/springframework/http/HttpAuthentication.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/HttpAuthentication.java
@@ -19,7 +19,7 @@ package org.springframework.http;
 /**
  * Represents an abstract HTTP Authentication. Possible subclasses include 
  * representations of HTTP Basic Authentication and HTTP Digest Authentication.
- * @see <a href="http://www.ietf.org/rfc/rfc2617.txt">RFC2617</a>
+ * @see <a href="https://www.ietf.org/rfc/rfc2617.txt">RFC2617</a>
  * @author Jonathan Sweemer
  * @author Roy Clarkson
  * @since 1.0

--- a/spring-android-rest-template/src/main/java/org/springframework/http/HttpBasicAuthentication.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/HttpBasicAuthentication.java
@@ -22,7 +22,7 @@ import org.springframework.util.Base64Utils;
  * Represents HTTP Basic Authentication. Intended for use
  * with {@link org.springframework.http.client.ClientHttpRequest}
  * and {@link org.springframework.web.client.RestTemplate}.
- * @see <a href="http://www.ietf.org/rfc/rfc2617.txt">RFC2617</a>
+ * @see <a href="https://www.ietf.org/rfc/rfc2617.txt">RFC2617</a>
  * @author Jonathan Sweemer
  * @author Roy Clarkson
  * @since 1.0

--- a/spring-android-rest-template/src/main/java/org/springframework/http/HttpEntity.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/HttpEntity.java
@@ -27,11 +27,11 @@ import org.springframework.util.ObjectUtils;
  * HttpHeaders headers = new HttpHeaders();
  * headers.setContentType(MediaType.TEXT_PLAIN);
  * HttpEntity&lt;String&gt; entity = new HttpEntity&lt;String&gt;(helloWorld, headers);
- * URI location = template.postForLocation("http://example.com", entity);
+ * URI location = template.postForLocation("https://example.com", entity);
  * </pre>
  * or
  * <pre class="code">
- * HttpEntity&lt;String&gt; entity = template.getForEntity("http://example.com", String.class);
+ * HttpEntity&lt;String&gt; entity = template.getForEntity("https://example.com", String.class);
  * String body = entity.getBody();
  * MediaType contentType = entity.getHeaders().getContentType();
  * </pre>

--- a/spring-android-rest-template/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/HttpHeaders.java
@@ -64,262 +64,262 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 
 	/**
 	 * The HTTP {@code Accept} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.3.2">Section 5.3.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.2">Section 5.3.2 of RFC 7231</a>
 	 */
 	public static final String ACCEPT = "Accept";
 	/**
 	 * The HTTP {@code Accept-Charset} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.3.3">Section 5.3.3 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.3">Section 5.3.3 of RFC 7231</a>
 	 */
 	public static final String ACCEPT_CHARSET = "Accept-Charset";
 	/**
 	 * The HTTP {@code Accept-Encoding} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.3.4">Section 5.3.4 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.4">Section 5.3.4 of RFC 7231</a>
 	 */
 	public static final String ACCEPT_ENCODING = "Accept-Encoding";
 	/**
 	 * The HTTP {@code Accept-Language} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.3.5">Section 5.3.5 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.3.5">Section 5.3.5 of RFC 7231</a>
 	 */
 	public static final String ACCEPT_LANGUAGE = "Accept-Language";
 	/**
 	 * The HTTP {@code Accept-Ranges} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-2.3">Section 5.3.5 of RFC 7233</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-2.3">Section 5.3.5 of RFC 7233</a>
 	 */
 	public static final String ACCEPT_RANGES = "Accept-Ranges";
 	/**
 	 * The HTTP {@code Age} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7234#section-5.1">Section 5.1 of RFC 7234</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.1">Section 5.1 of RFC 7234</a>
 	 */
 	public static final String AGE = "Age";
 	/**
 	 * The HTTP {@code Allow} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.4.1">Section 7.4.1 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.4.1">Section 7.4.1 of RFC 7231</a>
 	 */
 	public static final String ALLOW = "Allow";
 	/**
 	 * The HTTP {@code Authorization} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-4.2">Section 4.2 of RFC 7235</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.2">Section 4.2 of RFC 7235</a>
 	 */
 	public static final String AUTHORIZATION = "Authorization";
 	/**
 	 * The HTTP {@code Cache-Control} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7234#section-5.2">Section 5.2 of RFC 7234</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.2">Section 5.2 of RFC 7234</a>
 	 */
 	public static final String CACHE_CONTROL = "Cache-Control";
 	/**
 	 * The HTTP {@code Connection} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-6.1">Section 6.1 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-6.1">Section 6.1 of RFC 7230</a>
 	 */
 	public static final String CONNECTION = "Connection";
 	/**
 	 * The HTTP {@code Content-Encoding} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-3.1.2.2">Section 3.1.2.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.2.2">Section 3.1.2.2 of RFC 7231</a>
 	 */
 	public static final String CONTENT_ENCODING = "Content-Encoding";
 	/**
 	 * The HTTP {@code Content-Disposition} header field name
-	 * @see <a href="http://tools.ietf.org/html/rfc6266">RFC 6266</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6266">RFC 6266</a>
 	 */
 	public static final String CONTENT_DISPOSITION = "Content-Disposition";
 	/**
 	 * The HTTP {@code Content-Language} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-3.1.3.2">Section 3.1.3.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.3.2">Section 3.1.3.2 of RFC 7231</a>
 	 */
 	public static final String CONTENT_LANGUAGE = "Content-Language";
 	/**
 	 * The HTTP {@code Content-Length} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-3.3.2">Section 3.3.2 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-3.3.2">Section 3.3.2 of RFC 7230</a>
 	 */
 	public static final String CONTENT_LENGTH = "Content-Length";
 	/**
 	 * The HTTP {@code Content-Location} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-3.1.4.2">Section 3.1.4.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.4.2">Section 3.1.4.2 of RFC 7231</a>
 	 */
 	public static final String CONTENT_LOCATION = "Content-Location";
 	/**
 	 * The HTTP {@code Content-Range} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-4.2">Section 4.2 of RFC 7233</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-4.2">Section 4.2 of RFC 7233</a>
 	 */
 	public static final String CONTENT_RANGE = "Content-Range";
 	/**
 	 * The HTTP {@code Content-Type} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-3.1.1.5">Section 3.1.1.5 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.5">Section 3.1.1.5 of RFC 7231</a>
 	 */
 	public static final String CONTENT_TYPE = "Content-Type";
 	/**
 	 * The HTTP {@code Cookie} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc2109#section-4.3.4">Section 4.3.4 of RFC 2109</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2109#section-4.3.4">Section 4.3.4 of RFC 2109</a>
 	 */
 	public static final String COOKIE = "Cookie";
 	/**
 	 * The HTTP {@code Date} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.1.1.2">Section 7.1.1.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.2">Section 7.1.1.2 of RFC 7231</a>
 	 */
 	public static final String DATE = "Date";
 	/**
 	 * The HTTP {@code ETag} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-2.3">Section 2.3 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-2.3">Section 2.3 of RFC 7232</a>
 	 */
 	public static final String ETAG = "ETag";
 	/**
 	 * The HTTP {@code Expect} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.1.1">Section 5.1.1 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.1.1">Section 5.1.1 of RFC 7231</a>
 	 */
 	public static final String EXPECT = "Expect";
 	/**
 	 * The HTTP {@code Expires} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7234#section-5.3">Section 5.3 of RFC 7234</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.3">Section 5.3 of RFC 7234</a>
 	 */
 	public static final String EXPIRES = "Expires";
 	/**
 	 * The HTTP {@code From} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.5.1">Section 5.5.1 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.5.1">Section 5.5.1 of RFC 7231</a>
 	 */
 	public static final String FROM = "From";
 	/**
 	 * The HTTP {@code Host} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-5.4">Section 5.4 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-5.4">Section 5.4 of RFC 7230</a>
 	 */
 	public static final String HOST = "Host";
 	/**
 	 * The HTTP {@code If-Match} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-3.1">Section 3.1 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.1">Section 3.1 of RFC 7232</a>
 	 */
 	public static final String IF_MATCH = "If-Match";
 	/**
 	 * The HTTP {@code If-Modified-Since} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-3.3">Section 3.3 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.3">Section 3.3 of RFC 7232</a>
 	 */
 	public static final String IF_MODIFIED_SINCE = "If-Modified-Since";
 	/**
 	 * The HTTP {@code If-None-Match} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-3.2">Section 3.2 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.2">Section 3.2 of RFC 7232</a>
 	 */
 	public static final String IF_NONE_MATCH = "If-None-Match";
 	/**
 	 * The HTTP {@code If-Range} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-3.2">Section 3.2 of RFC 7233</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-3.2">Section 3.2 of RFC 7233</a>
 	 */
 	public static final String IF_RANGE = "If-Range";
 	/**
 	 * The HTTP {@code If-Unmodified-Since} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-3.4">Section 3.4 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-3.4">Section 3.4 of RFC 7232</a>
 	 */
 	public static final String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
 	/**
 	 * The HTTP {@code Last-Modified} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-2.2">Section 2.2 of RFC 7232</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-2.2">Section 2.2 of RFC 7232</a>
 	 */
 	public static final String LAST_MODIFIED = "Last-Modified";
 	/**
 	 * The HTTP {@code Link} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc5988">RFC 5988</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc5988">RFC 5988</a>
 	 */
 	public static final String LINK = "Link";
 	/**
 	 * The HTTP {@code Location} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.1.2">Section 7.1.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.2">Section 7.1.2 of RFC 7231</a>
 	 */
 	public static final String LOCATION = "Location";
 	/**
 	 * The HTTP {@code Max-Forwards} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.1.2">Section 5.1.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.1.2">Section 5.1.2 of RFC 7231</a>
 	 */
 	public static final String MAX_FORWARDS = "Max-Forwards";
 	/**
 	 * The HTTP {@code Origin} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc6454">RFC 6454</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6454">RFC 6454</a>
 	 */
 	public static final String ORIGIN = "Origin";
 	/**
 	 * The HTTP {@code Pragma} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7234#section-5.4">Section 5.4 of RFC 7234</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.4">Section 5.4 of RFC 7234</a>
 	 */
 	public static final String PRAGMA = "Pragma";
 	/**
 	 * The HTTP {@code Proxy-Authenticate} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-4.3">Section 4.3 of RFC 7235</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.3">Section 4.3 of RFC 7235</a>
 	 */
 	public static final String PROXY_AUTHENTICATE = "Proxy-Authenticate";
 	/**
 	 * The HTTP {@code Proxy-Authorization} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-4.4">Section 4.4 of RFC 7235</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.4">Section 4.4 of RFC 7235</a>
 	 */
 	public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
 	/**
 	 * The HTTP {@code Range} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-3.1">Section 3.1 of RFC 7233</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-3.1">Section 3.1 of RFC 7233</a>
 	 */
 	public static final String RANGE = "Range";
 	/**
 	 * The HTTP {@code Referer} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.5.2">Section 5.5.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.5.2">Section 5.5.2 of RFC 7231</a>
 	 */
 	public static final String REFERER = "Referer";
 	/**
 	 * The HTTP {@code Retry-After} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.1.3">Section 7.1.3 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.3">Section 7.1.3 of RFC 7231</a>
 	 */
 	public static final String RETRY_AFTER = "Retry-After";
 	/**
 	 * The HTTP {@code Server} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.4.2">Section 7.4.2 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.4.2">Section 7.4.2 of RFC 7231</a>
 	 */
 	public static final String SERVER = "Server";
 	/**
 	 * The HTTP {@code Set-Cookie} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc2109#section-4.2.2">Section 4.2.2 of RFC 2109</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2109#section-4.2.2">Section 4.2.2 of RFC 2109</a>
 	 */
 	public static final String SET_COOKIE = "Set-Cookie";
 	/**
 	 * The HTTP {@code Set-Cookie2} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc2965">RFC 2965</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2965">RFC 2965</a>
 	 */
 	public static final String SET_COOKIE2 = "Set-Cookie2";
 	/**
 	 * The HTTP {@code TE} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-4.3">Section 4.3 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-4.3">Section 4.3 of RFC 7230</a>
 	 */
 	public static final String TE = "TE";
 	/**
 	 * The HTTP {@code Trailer} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-4.4">Section 4.4 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-4.4">Section 4.4 of RFC 7230</a>
 	 */
 	public static final String TRAILER = "Trailer";
 	/**
 	 * The HTTP {@code Transfer-Encoding} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-3.3.1">Section 3.3.1 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-3.3.1">Section 3.3.1 of RFC 7230</a>
 	 */
 	public static final String TRANSFER_ENCODING = "Transfer-Encoding";
 	/**
 	 * The HTTP {@code Upgrade} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-6.7">Section 6.7 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-6.7">Section 6.7 of RFC 7230</a>
 	 */
 	public static final String UPGRADE = "Upgrade";
 	/**
 	 * The HTTP {@code User-Agent} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-5.5.3">Section 5.5.3 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-5.5.3">Section 5.5.3 of RFC 7231</a>
 	 */
 	public static final String USER_AGENT = "User-Agent";
 	/**
 	 * The HTTP {@code Vary} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-7.1.4">Section 7.1.4 of RFC 7231</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">Section 7.1.4 of RFC 7231</a>
 	 */
 	public static final String VARY = "Vary";
 	/**
 	 * The HTTP {@code Via} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7230#section-5.7.1">Section 5.7.1 of RFC 7230</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7230#section-5.7.1">Section 5.7.1 of RFC 7230</a>
 	 */
 	public static final String VIA = "Via";
 	/**
 	 * The HTTP {@code Warning} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7234#section-5.5">Section 5.5 of RFC 7234</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7234#section-5.5">Section 5.5 of RFC 7234</a>
 	 */
 	public static final String WARNING = "Warning";
 	/**
 	 * The HTTP {@code WWW-Authenticate} header field name.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-4.1">Section 4.1 of RFC 7235</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-4.1">Section 4.1 of RFC 7235</a>
 	 */
 	public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
 

--- a/spring-android-rest-template/src/main/java/org/springframework/http/HttpStatus.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/HttpStatus.java
@@ -25,8 +25,8 @@ package org.springframework.http;
  * @author Sebastien Deleuze
  * @since 1.0
  * @see HttpStatus.Series
- * @see <a href="http://www.iana.org/assignments/http-status-codes">HTTP Status Code Registry</a>
- * @see <a href="http://en.wikipedia.org/wiki/List_of_HTTP_status_codes">List of HTTP status codes - Wikipedia</a>
+ * @see <a href="https://www.iana.org/assignments/http-status-codes">HTTP Status Code Registry</a>
+ * @see <a href="https://en.wikipedia.org/wiki/List_of_HTTP_status_codes">List of HTTP status codes - Wikipedia</a>
  */
 public enum HttpStatus {
 
@@ -34,22 +34,22 @@ public enum HttpStatus {
 
 	/**
 	 * {@code 100 Continue}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.2.1">HTTP/1.1: Semantics and Content, section 6.2.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.2.1">HTTP/1.1: Semantics and Content, section 6.2.1</a>
 	 */
 	CONTINUE(100, "Continue"),
 	/**
 	 * {@code 101 Switching Protocols}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.2.2">HTTP/1.1: Semantics and Content, section 6.2.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.2.2">HTTP/1.1: Semantics and Content, section 6.2.2</a>
 	 */
 	SWITCHING_PROTOCOLS(101, "Switching Protocols"),
 	/**
 	 * {@code 102 Processing}.
-	 * @see <a href="http://tools.ietf.org/html/rfc2518#section-10.1">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2518#section-10.1">WebDAV</a>
 	 */
 	PROCESSING(102, "Processing"),
 	/**
 	 * {@code 103 Checkpoint}.
-	 * @see <a href="http://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal">A proposal for supporting
+	 * @see <a href="https://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal">A proposal for supporting
 	 * resumable POST/PUT HTTP requests in HTTP/1.0</a>
 	 */
 	CHECKPOINT(103, "Checkpoint"),
@@ -58,52 +58,52 @@ public enum HttpStatus {
 
 	/**
 	 * {@code 200 OK}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.1">HTTP/1.1: Semantics and Content, section 6.3.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.1">HTTP/1.1: Semantics and Content, section 6.3.1</a>
 	 */
 	OK(200, "OK"),
 	/**
 	 * {@code 201 Created}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.2">HTTP/1.1: Semantics and Content, section 6.3.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.2">HTTP/1.1: Semantics and Content, section 6.3.2</a>
 	 */
 	CREATED(201, "Created"),
 	/**
 	 * {@code 202 Accepted}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.3">HTTP/1.1: Semantics and Content, section 6.3.3</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.3">HTTP/1.1: Semantics and Content, section 6.3.3</a>
 	 */
 	ACCEPTED(202, "Accepted"),
 	/**
 	 * {@code 203 Non-Authoritative Information}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.4">HTTP/1.1: Semantics and Content, section 6.3.4</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.4">HTTP/1.1: Semantics and Content, section 6.3.4</a>
 	 */
 	NON_AUTHORITATIVE_INFORMATION(203, "Non-Authoritative Information"),
 	/**
 	 * {@code 204 No Content}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.5">HTTP/1.1: Semantics and Content, section 6.3.5</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.5">HTTP/1.1: Semantics and Content, section 6.3.5</a>
 	 */
 	NO_CONTENT(204, "No Content"),
 	/**
 	 * {@code 205 Reset Content}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.3.6">HTTP/1.1: Semantics and Content, section 6.3.6</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.3.6">HTTP/1.1: Semantics and Content, section 6.3.6</a>
 	 */
 	RESET_CONTENT(205, "Reset Content"),
 	/**
 	 * {@code 206 Partial Content}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-4.1">HTTP/1.1: Range Requests, section 4.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-4.1">HTTP/1.1: Range Requests, section 4.1</a>
 	 */
 	PARTIAL_CONTENT(206, "Partial Content"),
 	/**
 	 * {@code 207 Multi-Status}.
-	 * @see <a href="http://tools.ietf.org/html/rfc4918#section-13">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc4918#section-13">WebDAV</a>
 	 */
 	MULTI_STATUS(207, "Multi-Status"),
 	/**
 	 * {@code 208 Already Reported}.
-	 * @see <a href="http://tools.ietf.org/html/rfc5842#section-7.1">WebDAV Binding Extensions</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc5842#section-7.1">WebDAV Binding Extensions</a>
 	 */
 	ALREADY_REPORTED(208, "Already Reported"),
 	/**
 	 * {@code 226 IM Used}.
-	 * @see <a href="http://tools.ietf.org/html/rfc3229#section-10.4.1">Delta encoding in HTTP</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc3229#section-10.4.1">Delta encoding in HTTP</a>
 	 */
 	IM_USED(226, "IM Used"),
 
@@ -111,51 +111,51 @@ public enum HttpStatus {
 
 	/**
 	 * {@code 300 Multiple Choices}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.1">HTTP/1.1: Semantics and Content, section 6.4.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.1">HTTP/1.1: Semantics and Content, section 6.4.1</a>
 	 */
 	MULTIPLE_CHOICES(300, "Multiple Choices"),
 	/**
 	 * {@code 301 Moved Permanently}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.2">HTTP/1.1: Semantics and Content, section 6.4.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.2">HTTP/1.1: Semantics and Content, section 6.4.2</a>
 	 */
 	MOVED_PERMANENTLY(301, "Moved Permanently"),
 	/**
 	 * {@code 302 Found}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.3">HTTP/1.1: Semantics and Content, section 6.4.3</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.3">HTTP/1.1: Semantics and Content, section 6.4.3</a>
 	 */
 	FOUND(302, "Found"),
 	/**
 	 * {@code 302 Moved Temporarily}.
-	 * @see <a href="http://tools.ietf.org/html/rfc1945#section-9.3">HTTP/1.0, section 9.3</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc1945#section-9.3">HTTP/1.0, section 9.3</a>
 	 * @deprecated In favor of {@link #FOUND} which will be returned from {@code HttpStatus.valueOf(302)}
 	 */
 	@Deprecated
 	MOVED_TEMPORARILY(302, "Moved Temporarily"),
 	/**
 	 * {@code 303 See Other}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.4">HTTP/1.1: Semantics and Content, section 6.4.4</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.4">HTTP/1.1: Semantics and Content, section 6.4.4</a>
 	 */
 	SEE_OTHER(303, "See Other"),
 	/**
 	 * {@code 304 Not Modified}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-4.1">HTTP/1.1: Conditional Requests, section 4.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-4.1">HTTP/1.1: Conditional Requests, section 4.1</a>
 	 */
 	NOT_MODIFIED(304, "Not Modified"),
 	/**
 	 * {@code 305 Use Proxy}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.5">HTTP/1.1: Semantics and Content, section 6.4.5</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.5">HTTP/1.1: Semantics and Content, section 6.4.5</a>
 	 * @deprecated due to security concerns regarding in-band configuration of a proxy
 	 */
 	@Deprecated
 	USE_PROXY(305, "Use Proxy"),
 	/**
 	 * {@code 307 Temporary Redirect}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.4.7">HTTP/1.1: Semantics and Content, section 6.4.7</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.4.7">HTTP/1.1: Semantics and Content, section 6.4.7</a>
 	 */
 	TEMPORARY_REDIRECT(307, "Temporary Redirect"),
 	/**
 	 * {@code 308 Permanent Redirect}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7238">RFC 7238</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7238">RFC 7238</a>
 	 */
 	PERMANENT_REDIRECT(308, "Permanent Redirect"),
 
@@ -163,78 +163,78 @@ public enum HttpStatus {
 
 	/**
 	 * {@code 400 Bad Request}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.1">HTTP/1.1: Semantics and Content, section 6.5.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.1">HTTP/1.1: Semantics and Content, section 6.5.1</a>
 	 */
 	BAD_REQUEST(400, "Bad Request"),
 	/**
 	 * {@code 401 Unauthorized}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-3.1">HTTP/1.1: Authentication, section 3.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-3.1">HTTP/1.1: Authentication, section 3.1</a>
 	 */
 	UNAUTHORIZED(401, "Unauthorized"),
 	/**
 	 * {@code 402 Payment Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.2">HTTP/1.1: Semantics and Content, section 6.5.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.2">HTTP/1.1: Semantics and Content, section 6.5.2</a>
 	 */
 	PAYMENT_REQUIRED(402, "Payment Required"),
 	/**
 	 * {@code 403 Forbidden}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.3">HTTP/1.1: Semantics and Content, section 6.5.3</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.3">HTTP/1.1: Semantics and Content, section 6.5.3</a>
 	 */
 	FORBIDDEN(403, "Forbidden"),
 	/**
 	 * {@code 404 Not Found}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.4">HTTP/1.1: Semantics and Content, section 6.5.4</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.4">HTTP/1.1: Semantics and Content, section 6.5.4</a>
 	 */
 	NOT_FOUND(404, "Not Found"),
 	/**
 	 * {@code 405 Method Not Allowed}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.5">HTTP/1.1: Semantics and Content, section 6.5.5</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.5">HTTP/1.1: Semantics and Content, section 6.5.5</a>
 	 */
 	METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
 	/**
 	 * {@code 406 Not Acceptable}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.6">HTTP/1.1: Semantics and Content, section 6.5.6</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.6">HTTP/1.1: Semantics and Content, section 6.5.6</a>
 	 */
 	NOT_ACCEPTABLE(406, "Not Acceptable"),
 	/**
 	 * {@code 407 Proxy Authentication Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7235#section-3.2">HTTP/1.1: Authentication, section 3.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7235#section-3.2">HTTP/1.1: Authentication, section 3.2</a>
 	 */
 	PROXY_AUTHENTICATION_REQUIRED(407, "Proxy Authentication Required"),
 	/**
 	 * {@code 408 Request Timeout}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.7">HTTP/1.1: Semantics and Content, section 6.5.7</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.7">HTTP/1.1: Semantics and Content, section 6.5.7</a>
 	 */
 	REQUEST_TIMEOUT(408, "Request Timeout"),
 	/**
 	 * {@code 409 Conflict}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.8">HTTP/1.1: Semantics and Content, section 6.5.8</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.8">HTTP/1.1: Semantics and Content, section 6.5.8</a>
 	 */
 	CONFLICT(409, "Conflict"),
 	/**
 	 * {@code 410 Gone}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.9">HTTP/1.1: Semantics and Content, section 6.5.9</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.9">HTTP/1.1: Semantics and Content, section 6.5.9</a>
 	 */
 	GONE(410, "Gone"),
 	/**
 	 * {@code 411 Length Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.10">HTTP/1.1: Semantics and Content, section 6.5.10</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.10">HTTP/1.1: Semantics and Content, section 6.5.10</a>
 	 */
 	LENGTH_REQUIRED(411, "Length Required"),
 	/**
 	 * {@code 412 Precondition failed}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7232#section-4.2">HTTP/1.1: Conditional Requests, section 4.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7232#section-4.2">HTTP/1.1: Conditional Requests, section 4.2</a>
 	 */
 	PRECONDITION_FAILED(412, "Precondition Failed"),
 	/**
 	 * {@code 413 Payload Too Large}.
 	 * @since 4.1
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.11">HTTP/1.1: Semantics and Content, section 6.5.11</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.11">HTTP/1.1: Semantics and Content, section 6.5.11</a>
 	 */
 	PAYLOAD_TOO_LARGE(413, "Payload Too Large"),
 	/**
 	 * {@code 413 Request Entity Too Large}.
-	 * @see <a href="http://tools.ietf.org/html/rfc2616#section-10.4.14">HTTP/1.1, section 10.4.14</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2616#section-10.4.14">HTTP/1.1, section 10.4.14</a>
 	 * @deprecated In favor of {@link #PAYLOAD_TOO_LARGE} which will be returned from {@code HttpStatus.valueOf(413)}
 	 */
 	@Deprecated
@@ -242,84 +242,84 @@ public enum HttpStatus {
 	/**
 	 * {@code 414 URI Too Long}.
 	 * @since 4.1
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.12">HTTP/1.1: Semantics and Content, section 6.5.12</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.12">HTTP/1.1: Semantics and Content, section 6.5.12</a>
 	 */
 	URI_TOO_LONG(414, "URI Too Long"),
 	/**
 	 * {@code 414 Request-URI Too Long}.
-	 * @see <a href="http://tools.ietf.org/html/rfc2616#section-10.4.15">HTTP/1.1, section 10.4.15</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2616#section-10.4.15">HTTP/1.1, section 10.4.15</a>
 	 * @deprecated In favor of {@link #URI_TOO_LONG} which will be returned from {@code HttpStatus.valueOf(414)}
 	 */
 	@Deprecated
 	REQUEST_URI_TOO_LONG(414, "Request-URI Too Long"),
 	/**
 	 * {@code 415 Unsupported Media Type}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.13">HTTP/1.1: Semantics and Content, section 6.5.13</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.13">HTTP/1.1: Semantics and Content, section 6.5.13</a>
 	 */
 	UNSUPPORTED_MEDIA_TYPE(415, "Unsupported Media Type"),
 	/**
 	 * {@code 416 Requested Range Not Satisfiable}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7233#section-4.4">HTTP/1.1: Range Requests, section 4.4</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7233#section-4.4">HTTP/1.1: Range Requests, section 4.4</a>
 	 */
 	REQUESTED_RANGE_NOT_SATISFIABLE(416, "Requested range not satisfiable"),
 	/**
 	 * {@code 417 Expectation Failed}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.5.14">HTTP/1.1: Semantics and Content, section 6.5.14</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.14">HTTP/1.1: Semantics and Content, section 6.5.14</a>
 	 */
 	EXPECTATION_FAILED(417, "Expectation Failed"),
 	/**
 	 * {@code 418 I'm a teapot}.
-	 * @see <a href="http://tools.ietf.org/html/rfc2324#section-2.3.2">HTCPCP/1.0</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2324#section-2.3.2">HTCPCP/1.0</a>
 	 */
 	I_AM_A_TEAPOT(418, "I'm a teapot"),
 	/**
-	 * @deprecated See <a href="http://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
+	 * @deprecated See <a href="https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
 	 */
 	@Deprecated
 	INSUFFICIENT_SPACE_ON_RESOURCE(419, "Insufficient Space On Resource"),
 	/**
-	 * @deprecated See <a href="http://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
+	 * @deprecated See <a href="https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
 	 */
 	@Deprecated
 	METHOD_FAILURE(420, "Method Failure"),
 	/**
-	 * @deprecated See <a href="http://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
+	 * @deprecated See <a href="https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt">WebDAV Draft Changes</a>
 	 */
 	@Deprecated
 	DESTINATION_LOCKED(421, "Destination Locked"),
 	/**
 	 * {@code 422 Unprocessable Entity}.
-	 * @see <a href="http://tools.ietf.org/html/rfc4918#section-11.2">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc4918#section-11.2">WebDAV</a>
 	 */
 	UNPROCESSABLE_ENTITY(422, "Unprocessable Entity"),
 	/**
 	 * {@code 423 Locked}.
-	 * @see <a href="http://tools.ietf.org/html/rfc4918#section-11.3">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc4918#section-11.3">WebDAV</a>
 	 */
 	LOCKED(423, "Locked"),
 	/**
 	 * {@code 424 Failed Dependency}.
-	 * @see <a href="http://tools.ietf.org/html/rfc4918#section-11.4">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc4918#section-11.4">WebDAV</a>
 	 */
 	FAILED_DEPENDENCY(424, "Failed Dependency"),
 	/**
 	 * {@code 426 Upgrade Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc2817#section-6">Upgrading to TLS Within HTTP/1.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2817#section-6">Upgrading to TLS Within HTTP/1.1</a>
 	 */
 	UPGRADE_REQUIRED(426, "Upgrade Required"),
 	/**
 	 * {@code 428 Precondition Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc6585#section-3">Additional HTTP Status Codes</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6585#section-3">Additional HTTP Status Codes</a>
 	 */
 	PRECONDITION_REQUIRED(428, "Precondition Required"),
 	/**
 	 * {@code 429 Too Many Requests}.
-	 * @see <a href="http://tools.ietf.org/html/rfc6585#section-4">Additional HTTP Status Codes</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6585#section-4">Additional HTTP Status Codes</a>
 	 */
 	TOO_MANY_REQUESTS(429, "Too Many Requests"),
 	/**
 	 * {@code 431 Request Header Fields Too Large}.
-	 * @see <a href="http://tools.ietf.org/html/rfc6585#section-5">Additional HTTP Status Codes</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6585#section-5">Additional HTTP Status Codes</a>
 	 */
 	REQUEST_HEADER_FIELDS_TOO_LARGE(431, "Request Header Fields Too Large"),
 
@@ -327,47 +327,47 @@ public enum HttpStatus {
 
 	/**
 	 * {@code 500 Internal Server Error}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.1">HTTP/1.1: Semantics and Content, section 6.6.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.1">HTTP/1.1: Semantics and Content, section 6.6.1</a>
 	 */
 	INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
 	/**
 	 * {@code 501 Not Implemented}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.2">HTTP/1.1: Semantics and Content, section 6.6.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.2">HTTP/1.1: Semantics and Content, section 6.6.2</a>
 	 */
 	NOT_IMPLEMENTED(501, "Not Implemented"),
 	/**
 	 * {@code 502 Bad Gateway}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.3">HTTP/1.1: Semantics and Content, section 6.6.3</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.3">HTTP/1.1: Semantics and Content, section 6.6.3</a>
 	 */
 	BAD_GATEWAY(502, "Bad Gateway"),
 	/**
 	 * {@code 503 Service Unavailable}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.4">HTTP/1.1: Semantics and Content, section 6.6.4</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.4">HTTP/1.1: Semantics and Content, section 6.6.4</a>
 	 */
 	SERVICE_UNAVAILABLE(503, "Service Unavailable"),
 	/**
 	 * {@code 504 Gateway Timeout}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.5">HTTP/1.1: Semantics and Content, section 6.6.5</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.5">HTTP/1.1: Semantics and Content, section 6.6.5</a>
 	 */
 	GATEWAY_TIMEOUT(504, "Gateway Timeout"),
 	/**
 	 * {@code 505 HTTP Version Not Supported}.
-	 * @see <a href="http://tools.ietf.org/html/rfc7231#section-6.6.6">HTTP/1.1: Semantics and Content, section 6.6.6</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.6.6">HTTP/1.1: Semantics and Content, section 6.6.6</a>
 	 */
 	HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version not supported"),
 	/**
 	 * {@code 506 Variant Also Negotiates}
-	 * @see <a href="http://tools.ietf.org/html/rfc2295#section-8.1">Transparent Content Negotiation</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2295#section-8.1">Transparent Content Negotiation</a>
 	 */
 	VARIANT_ALSO_NEGOTIATES(506, "Variant Also Negotiates"),
 	/**
 	 * {@code 507 Insufficient Storage}
-	 * @see <a href="http://tools.ietf.org/html/rfc4918#section-11.5">WebDAV</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc4918#section-11.5">WebDAV</a>
 	 */
 	INSUFFICIENT_STORAGE(507, "Insufficient Storage"),
 	/**
 	 * {@code 508 Loop Detected}
-	 * @see <a href="http://tools.ietf.org/html/rfc5842#section-7.2">WebDAV Binding Extensions</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc5842#section-7.2">WebDAV Binding Extensions</a>
 	 */
 	LOOP_DETECTED(508, "Loop Detected"),
 	/**
@@ -376,12 +376,12 @@ public enum HttpStatus {
 	BANDWIDTH_LIMIT_EXCEEDED(509, "Bandwidth Limit Exceeded"),
 	/**
 	 * {@code 510 Not Extended}
-	 * @see <a href="http://tools.ietf.org/html/rfc2774#section-7">HTTP Extension Framework</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2774#section-7">HTTP Extension Framework</a>
 	 */
 	NOT_EXTENDED(510, "Not Extended"),
 	/**
 	 * {@code 511 Network Authentication Required}.
-	 * @see <a href="http://tools.ietf.org/html/rfc6585#section-6">Additional HTTP Status Codes</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc6585#section-6">Additional HTTP Status Codes</a>
 	 */
 	NETWORK_AUTHENTICATION_REQUIRED(511, "Network Authentication Required");
 

--- a/spring-android-rest-template/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/MediaType.java
@@ -48,7 +48,7 @@ import org.springframework.util.comparator.CompoundComparator;
  * @author Roy Clarkson
  * @author Rossen Stoyanchev
  * @since 1.0
- * @see <a href="http://tools.ietf.org/html/rfc2616#section-3.7">HTTP 1.1, section 3.7</a>
+ * @see <a href="https://tools.ietf.org/html/rfc2616#section-3.7">HTTP 1.1, section 3.7</a>
  */
 public class MediaType implements Comparable<MediaType> {
 
@@ -368,7 +368,7 @@ public class MediaType implements Comparable<MediaType> {
 	/**
 	 * Checks the given token string for illegal characters, as defined in RFC 2616, section 2.2.
 	 * @throws IllegalArgumentException in case of illegal characters
-	 * @see <a href="http://tools.ietf.org/html/rfc2616#section-2.2">HTTP 1.1, section 2.2</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2616#section-2.2">HTTP 1.1, section 2.2</a>
 	 */
 	private void checkToken(String token) {
 		for (int i=0; i < token.length(); i++ ) {
@@ -816,7 +816,7 @@ public class MediaType implements Comparable<MediaType> {
 	 * <blockquote>audio/basic == text/html</blockquote>
 	 * <blockquote>audio/basic == audio/wave</blockquote>
 	 * @param mediaTypes the list of media types to be sorted
-	 * @see <a href="http://tools.ietf.org/html/rfc2616#section-14.1">HTTP 1.1, section 14.1</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc2616#section-14.1">HTTP 1.1, section 14.1</a>
 	 */
 	public static void sortBySpecificity(List<MediaType> mediaTypes) {
 		Assert.notNull(mediaTypes, "'mediaTypes' must not be null");

--- a/spring-android-rest-template/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/ResponseEntity.java
@@ -23,7 +23,7 @@ import org.springframework.util.MultiValueMap;
  *
  * <p>Returned by {@link org.springframework.web.client.RestTemplate#getForEntity}:
  * <pre class="code">
- * ResponseEntity&lt;String&gt; entity = template.getForEntity("http://example.com", String.class);
+ * ResponseEntity&lt;String&gt; entity = template.getForEntity("https://example.com", String.class);
  * String body = entity.getBody();
  * MediaType contentType = entity.getHeaders().getContentType();
  * HttpStatus statusCode = entity.getStatusCode();

--- a/spring-android-rest-template/src/main/java/org/springframework/http/client/HttpComponentsAndroidClientHttpRequestFactory.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/client/HttpComponentsAndroidClientHttpRequestFactory.java
@@ -49,7 +49,7 @@ import org.springframework.util.Assert;
 /**
  * {@link org.springframework.http.client.ClientHttpRequestFactory} implementation that
  * uses Android native
- * <a href="http://hc.apache.org/httpcomponents-client-ga/httpclient/">Apache
+ * <a href="https://hc.apache.org/httpcomponents-client-ga/httpclient/">Apache
  * HttpClient 4.0</a> to create requests.
  * 
  * <p>Allows to use a pre-configured {@link HttpClient} instance - potentially with authentication, HTTP connection

--- a/spring-android-rest-template/src/main/java/org/springframework/http/client/OkHttp3ClientHttpRequestFactory.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/client/OkHttp3ClientHttpRequestFactory.java
@@ -27,7 +27,7 @@ import org.springframework.util.Assert;
 
 /**
  * {@link ClientHttpRequestFactory} implementation that uses
- * <a href="http://square.github.io/okhttp/">OkHttp 3.x</a> to create requests.
+ * <a href="https://square.github.io/okhttp/">OkHttp 3.x</a> to create requests.
  *
  * @author Stéphane Nicolas
  * @author Luciano Leggieri

--- a/spring-android-rest-template/src/main/java/org/springframework/http/client/OkHttpClientHttpRequestFactory.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/client/OkHttpClientHttpRequestFactory.java
@@ -27,7 +27,7 @@ import org.springframework.util.Assert;
 
 /**
  * {@link ClientHttpRequestFactory} implementation that uses
- * <a href="http://square.github.io/okhttp/">OkHttp 2.x</a> to create requests.
+ * <a href="https://square.github.io/okhttp/">OkHttp 2.x</a> to create requests.
  *
  * @author Stéphane Nicolas
  * @author Luciano Leggieri

--- a/spring-android-rest-template/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
@@ -58,10 +58,10 @@ import org.springframework.util.StringUtils;
  * <p>For example, the following snippet shows how to submit an HTML form: <pre class="code"> RestTemplate template =
  * new RestTemplate(); // FormHttpMessageConverter is configured by default MultiValueMap&lt;String, String&gt; form =
  * new LinkedMultiValueMap&lt;String, String&gt;(); form.add("field 1", "value 1"); form.add("field 2", "value 2");
- * form.add("field 2", "value 3"); template.postForLocation("http://example.com/myForm", form); </pre> <p>The following
+ * form.add("field 2", "value 3"); template.postForLocation("https://example.com/myForm", form); </pre> <p>The following
  * snippet shows how to do a file upload: <pre class="code"> MultiValueMap&lt;String, Object&gt; parts = new
  * LinkedMultiValueMap&lt;String, Object&gt;(); parts.add("field 1", "value 1"); parts.add("file", new
- * ClassPathResource("myFile.jpg")); template.postForLocation("http://example.com/myFileUpload", parts); </pre>
+ * ClassPathResource("myFile.jpg")); template.postForLocation("https://example.com/myFileUpload", parts); </pre>
  *
  * <p>Some methods in this class were inspired by {@code org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity}.
  *

--- a/spring-android-rest-template/src/main/java/org/springframework/http/converter/json/MappingJackson2HttpMessageConverter.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/converter/json/MappingJackson2HttpMessageConverter.java
@@ -40,7 +40,7 @@ import org.springframework.util.Assert;
 
 /**
  * Implementation of {@link org.springframework.http.converter.HttpMessageConverter HttpMessageConverter}
- * that can read and write JSON using <a href="http://wiki.fasterxml.com/JacksonHome">Jackson 2.x's</a>  {@link ObjectMapper}.
+ * that can read and write JSON using <a href="https://wiki.fasterxml.com/JacksonHome">Jackson 2.x's</a>  {@link ObjectMapper}.
  *
  * <p>This converter can be used to bind to typed beans, or untyped {@link java.util.HashMap HashMap} instances.
  *

--- a/spring-android-rest-template/src/main/java/org/springframework/http/converter/xml/SourceHttpMessageConverter.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/http/converter/xml/SourceHttpMessageConverter.java
@@ -163,7 +163,7 @@ public class SourceHttpMessageConverter<T extends Source> extends AbstractHttpMe
 			XMLReader reader = newSAXParser.getXMLReader();
 			// older versions of the Android parser do not support this feature
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-				reader.setFeature("http://xml.org/sax/features/external-general-entities", isProcessExternalEntities());
+				reader.setFeature("http://www.xml.org/sax/features/external-general-entities", isProcessExternalEntities());
 			}
 			byte[] bytes = StreamUtils.copyToByteArray(body);
 			if (!isProcessExternalEntities()) {

--- a/spring-android-rest-template/src/main/java/org/springframework/web/client/RestOperations.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/web/client/RestOperations.java
@@ -399,7 +399,7 @@ public interface RestOperations {
 	 * The given {@link ParameterizedTypeReference} is used to pass generic type information:
 	 * <pre class="code">
 	 * ParameterizedTypeReference&lt;List&lt;MyBean&gt;&gt; myBean = new ParameterizedTypeReference&lt;List&lt;MyBean&gt;&gt;() {};
-	 * ResponseEntity&lt;List&lt;MyBean&gt;&gt; response = template.exchange(&quot;http://example.com&quot;,HttpMethod.GET, null, myBean);
+	 * ResponseEntity&lt;List&lt;MyBean&gt;&gt; response = template.exchange(&quot;https://example.com&quot;,HttpMethod.GET, null, myBean);
 	 * </pre>
 	 * @param url the URL
 	 * @param method the HTTP method (GET, POST, etc)
@@ -419,7 +419,7 @@ public interface RestOperations {
 	 * The given {@link ParameterizedTypeReference} is used to pass generic type information:
 	 * <pre class="code">
 	 * ParameterizedTypeReference&lt;List&lt;MyBean&gt;&gt; myBean = new ParameterizedTypeReference&lt;List&lt;MyBean&gt;&gt;() {};
-	 * ResponseEntity&lt;List&lt;MyBean&gt;&gt; response = template.exchange(&quot;http://example.com&quot;,HttpMethod.GET, null, myBean);
+	 * ResponseEntity&lt;List&lt;MyBean&gt;&gt; response = template.exchange(&quot;https://example.com&quot;,HttpMethod.GET, null, myBean);
 	 * </pre>
 	 * @param url the URL
 	 * @param method the HTTP method (GET, POST, etc)
@@ -438,7 +438,7 @@ public interface RestOperations {
 	 * The given {@link ParameterizedTypeReference} is used to pass generic type information:
 	 * <pre class="code">
 	 * ParameterizedTypeReference&lt;List&lt;MyBean&gt;&gt; myBean = new ParameterizedTypeReference&lt;List&lt;MyBean&gt;&gt;() {};
-	 * ResponseEntity&lt;List&lt;MyBean&gt;&gt; response = template.exchange(&quot;http://example.com&quot;,HttpMethod.GET, null, myBean);
+	 * ResponseEntity&lt;List&lt;MyBean&gt;&gt; response = template.exchange(&quot;https://example.com&quot;,HttpMethod.GET, null, myBean);
 	 * </pre>
 	 * @param url the URL
 	 * @param method the HTTP method (GET, POST, etc)

--- a/spring-android-rest-template/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -82,27 +82,27 @@ import android.util.Log;
  * in that URL using either a {@code String} variable arguments array, or a {@code Map<String, String>}.
  * The string varargs variant expands the given template variables in order, so that
  * <pre class="code">
- * String result = restTemplate.getForObject("http://example.com/hotels/{hotel}/bookings/{booking}", String.class, "42",
+ * String result = restTemplate.getForObject("https://example.com/hotels/{hotel}/bookings/{booking}", String.class, "42",
  * "21");
  * </pre>
- * will perform a GET on {@code http://example.com/hotels/42/bookings/21}. The map variant expands the template based
+ * will perform a GET on {@code https://example.com/hotels/42/bookings/21}. The map variant expands the template based
  * on variable name, and is therefore more useful when using many variables, or when a single variable is used multiple
  * times. For example:
  * <pre class="code">
  * Map&lt;String, String&gt; vars = Collections.singletonMap("hotel", "42");
- * String result = restTemplate.getForObject("http://example.com/hotels/{hotel}/rooms/{hotel}", String.class, vars);
+ * String result = restTemplate.getForObject("https://example.com/hotels/{hotel}/rooms/{hotel}", String.class, vars);
  * </pre>
- * will perform a GET on {@code http://example.com/hotels/42/rooms/42}. Alternatively, there are {@link URI} variant
+ * will perform a GET on {@code https://example.com/hotels/42/rooms/42}. Alternatively, there are {@link URI} variant
  * methods ({@link #getForObject(URI, Class)}), which do not allow for URI templates, but allow you to reuse a single,
  * expanded URI multiple times.
  *
  * <p>Furthermore, the {@code String}-argument methods assume that the URL String is unencoded. This means that
  * <pre class="code">
- * restTemplate.getForObject("http://example.com/hotel list");
+ * restTemplate.getForObject("https://example.com/hotel list");
  * </pre>
- * will perform a GET on {@code http://example.com/hotel%20list}. As a result, any URL passed that is already encoded
- * will be encoded twice (i.e. {@code http://example.com/hotel%20list} will become {@code
- * http://example.com/hotel%2520list}). If this behavior is undesirable, use the {@code URI}-argument methods, which
+ * will perform a GET on {@code https://example.com/hotel%20list}. As a result, any URL passed that is already encoded
+ * will be encoded twice (i.e. {@code https://example.com/hotel%20list} will become {@code
+ * https://example.com/hotel%2520list}). If this behavior is undesirable, use the {@code URI}-argument methods, which
  * will not perform any URL encoding.
  *
  * <p>Objects passed to and returned from these methods are converted to and from HTTP messages by

--- a/spring-android-rest-template/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
@@ -41,7 +41,7 @@ import org.springframework.util.StringUtils;
  * @author Arjen Poutsma
  * @author Phillip Webb
  * @since 2.0
- * @see <a href="http://tools.ietf.org/html/rfc3986#section-1.2.3">Hierarchical URIs</a>
+ * @see <a href="https://tools.ietf.org/html/rfc3986#section-1.2.3">Hierarchical URIs</a>
  */
 @SuppressWarnings("serial")
 final class HierarchicalUriComponents extends UriComponents {
@@ -453,7 +453,7 @@ final class HierarchicalUriComponents extends UriComponents {
 	/**
 	 * Enumeration used to identify the parts of a URI.
 	 * <p>Contains methods to indicate whether a given character is valid in a specific URI component.
-	 * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>
+	 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>
 	 */
 	static enum Type {
 
@@ -537,7 +537,7 @@ final class HierarchicalUriComponents extends UriComponents {
 
 		/**
 		 * Indicates whether the given character is in the {@code ALPHA} set.
-		 * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
 		 */
 		protected boolean isAlpha(int c) {
 			return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z';
@@ -545,7 +545,7 @@ final class HierarchicalUriComponents extends UriComponents {
 
 		/**
 		 * Indicates whether the given character is in the {@code DIGIT} set.
-		 * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
 		 */
 		protected boolean isDigit(int c) {
 			return c >= '0' && c <= '9';
@@ -553,7 +553,7 @@ final class HierarchicalUriComponents extends UriComponents {
 
 		/**
 		 * Indicates whether the given character is in the {@code gen-delims} set.
-		 * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
 		 */
 		protected boolean isGenericDelimiter(int c) {
 			return ':' == c || '/' == c || '?' == c || '#' == c || '[' == c || ']' == c || '@' == c;
@@ -561,7 +561,7 @@ final class HierarchicalUriComponents extends UriComponents {
 
 		/**
 		 * Indicates whether the given character is in the {@code sub-delims} set.
-		 * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
 		 */
 		protected boolean isSubDelimiter(int c) {
 			return '!' == c || '$' == c || '&' == c || '\'' == c || '(' == c || ')' == c || '*' == c || '+' == c ||
@@ -570,7 +570,7 @@ final class HierarchicalUriComponents extends UriComponents {
 
 		/**
 		 * Indicates whether the given character is in the {@code reserved} set.
-		 * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
 		 */
 		protected boolean isReserved(char c) {
 			return isGenericDelimiter(c) || isReserved(c);
@@ -578,7 +578,7 @@ final class HierarchicalUriComponents extends UriComponents {
 
 		/**
 		 * Indicates whether the given character is in the {@code unreserved} set.
-		 * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
 		 */
 		protected boolean isUnreserved(int c) {
 			return isAlpha(c) || isDigit(c) || '-' == c || '.' == c || '_' == c || '~' == c;
@@ -586,7 +586,7 @@ final class HierarchicalUriComponents extends UriComponents {
 
 		/**
 		 * Indicates whether the given character is in the {@code pchar} set.
-		 * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
+		 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>
 		 */
 		protected boolean isPchar(int c) {
 			return isUnreserved(c) || isSubDelimiter(c) || ':' == c || '@' == c;

--- a/spring-android-rest-template/src/main/java/org/springframework/web/util/OpaqueUriComponents.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/web/util/OpaqueUriComponents.java
@@ -32,7 +32,7 @@ import org.springframework.util.ObjectUtils;
  * @author Arjen Poutsma
  * @author Phillip Webb
  * @since 2.0
- * @see <a href="http://tools.ietf.org/html/rfc3986#section-1.2.3">Hierarchical vs Opaque URIs</a>
+ * @see <a href="https://tools.ietf.org/html/rfc3986#section-1.2.3">Hierarchical vs Opaque URIs</a>
  */
 @SuppressWarnings("serial")
 final class OpaqueUriComponents extends UriComponents {

--- a/spring-android-rest-template/src/main/java/org/springframework/web/util/UriTemplate.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/web/util/UriTemplate.java
@@ -37,7 +37,7 @@ import org.springframework.util.Assert;
  * @author Arjen Poutsma
  * @author Juergen Hoeller
  * @since 1.0
- * @see <a href="http://bitworking.org/projects/URI-Templates/">URI Templates</a>
+ * @see <a href="https://bitworking.org/projects/URI-Templates/">URI Templates</a>
  */
 @SuppressWarnings("serial")
 public class UriTemplate implements Serializable {
@@ -83,13 +83,13 @@ public class UriTemplate implements Serializable {
 	 * the Map values variable values. The order of variables is not significant.
 	 * <p>Example:
 	 * <pre class="code">
-	 * UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
+	 * UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
 	 * Map&lt;String, String&gt; uriVariables = new HashMap&lt;String, String&gt;();
 	 * uriVariables.put("booking", "42");
 	 * uriVariables.put("hotel", "Rest & Relax");
 	 * System.out.println(template.expand(uriVariables));
 	 * </pre>
-	 * will print: <blockquote>{@code http://example.com/hotels/Rest%20%26%20Relax/bookings/42}</blockquote>
+	 * will print: <blockquote>{@code https://example.com/hotels/Rest%20%26%20Relax/bookings/42}</blockquote>
 	 * @param uriVariables the map of URI variables
 	 * @return the expanded URI
 	 * @throws IllegalArgumentException if {@code uriVariables} is {@code null};
@@ -106,10 +106,10 @@ public class UriTemplate implements Serializable {
 	 * The order of variables is significant.
 	 * <p>Example:
 	 * <pre class="code">
-	 * UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
+	 * UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
 	 * System.out.println(template.expand("Rest & Relax", "42));
 	 * </pre>
-	 * will print: <blockquote>{@code http://example.com/hotels/Rest%20%26%20Relax/bookings/42}</blockquote>
+	 * will print: <blockquote>{@code https://example.com/hotels/Rest%20%26%20Relax/bookings/42}</blockquote>
 	 * @param uriVariableValues the array of URI variables
 	 * @return the expanded URI
 	 * @throws IllegalArgumentException if {@code uriVariables} is {@code null}
@@ -139,8 +139,8 @@ public class UriTemplate implements Serializable {
 	 * values are variable values, as occurred in the given URI.
 	 * <p>Example:
 	 * <pre class="code">
-	 * UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
-	 * System.out.println(template.match("http://example.com/hotels/1/bookings/42"));
+	 * UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
+	 * System.out.println(template.match("https://example.com/hotels/1/bookings/42"));
 	 * </pre>
 	 * will print: <blockquote>{@code {hotel=1, booking=42}}</blockquote>
 	 * @param uri the URI to match to

--- a/spring-android-rest-template/src/main/java/org/springframework/web/util/UriUtils.java
+++ b/spring-android-rest-template/src/main/java/org/springframework/web/util/UriUtils.java
@@ -37,7 +37,7 @@ import org.springframework.util.Assert;
  *
  * @author Arjen Poutsma
  * @since 1.0
- * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>
+ * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>
  */
 public abstract class UriUtils {
 

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -5,7 +5,7 @@ This document is the API specification for Spring for Android
 <div id="overviewBody">
     <p>
         If you are interested in commercial training, consultancy, and
-        support for Spring for Android, please visit <a href="http://spring.io/" target="_top">spring.io</a>.
+        support for Spring for Android, please visit <a href="https://spring.io/" target="_top">spring.io</a>.
     </p>
 </div>
 </body>

--- a/src/dist/readme.txt
+++ b/src/dist/readme.txt
@@ -6,7 +6,7 @@ https://jira.spring.io/browse/ANDROID
 
 Please consult the documentation located within the 'docs/reference' directory
 of this release and also visit the official Spring for Android home at:
-http://projects.spring.io/spring-android
+https://projects.spring.io/spring-android
 
 There you will find links to issue tracker, samples, and other resources.
 

--- a/test/spring-android-auth-test/src/main/java/org/springframework/social/connect/sqlite/SQLiteUsersConnectionRepositoryTest.java
+++ b/test/spring-android-auth-test/src/main/java/org/springframework/social/connect/sqlite/SQLiteUsersConnectionRepositoryTest.java
@@ -369,12 +369,12 @@ public class SQLiteUsersConnectionRepositoryTest extends AndroidTestCase {
 		connectionFactoryRegistry.addConnectionFactory(new TestTwitterConnectionFactory());
 		insertTwitterConnection();
 		Connection<TestTwitterApi> twitter = connectionRepository.findPrimaryConnection(TestTwitterApi.class);
-		assertEquals("http://twitter.com/kdonald/picture", twitter.getImageUrl());
+		assertEquals("https://twitter.com/kdonald/picture", twitter.getImageUrl());
 		twitter.sync();
-		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
+		assertEquals("https://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
 		connectionRepository.updateConnection(twitter);
 		Connection<TestTwitterApi> twitter2 = connectionRepository.findPrimaryConnection(TestTwitterApi.class);
-		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter2.getImageUrl());
+		assertEquals("https://twitter.com/kdonald/a_new_picture", twitter2.getImageUrl());
 	}
 
 	@MediumTest
@@ -400,8 +400,8 @@ public class SQLiteUsersConnectionRepositoryTest extends AndroidTestCase {
 		values.put("providerUserId", "1");
 		values.put("rank", 1);
 		values.put("displayName", "@kdonald");
-		values.put("profileUrl", "http://twitter.com/kdonald");
-		values.put("imageUrl", "http://twitter.com/kdonald/picture");
+		values.put("profileUrl", "https://twitter.com/kdonald");
+		values.put("imageUrl", "https://twitter.com/kdonald/picture");
 		values.put("accessToken", encrypt("123456789"));
 		values.put("secret", encrypt("987654321"));
 		values.putNull("refreshToken");
@@ -499,8 +499,8 @@ public class SQLiteUsersConnectionRepositoryTest extends AndroidTestCase {
 		assertEquals("facebook", connection.getKey().getProviderId());
 		assertEquals("9", connection.getKey().getProviderUserId());
 		assertEquals("Keith Donald", connection.getDisplayName());
-		assertEquals("http://facebook.com/keith.donald", connection.getProfileUrl());
-		assertEquals("http://facebook.com/keith.donald/picture", connection.getImageUrl());
+		assertEquals("https://facebook.com/keith.donald", connection.getProfileUrl());
+		assertEquals("https://facebook.com/keith.donald/picture", connection.getImageUrl());
 		assertTrue(connection.test());
 		TestFacebookApi api = connection.getApi();
 		assertNotNull(api);
@@ -512,13 +512,13 @@ public class SQLiteUsersConnectionRepositoryTest extends AndroidTestCase {
 	private void assertTwitterConnection(Connection<TestTwitterApi> twitter) {
 		assertEquals(new ConnectionKey("twitter", "1"), twitter.getKey());
 		assertEquals("@kdonald", twitter.getDisplayName());
-		assertEquals("http://twitter.com/kdonald", twitter.getProfileUrl());
-		assertEquals("http://twitter.com/kdonald/picture", twitter.getImageUrl());
+		assertEquals("https://twitter.com/kdonald", twitter.getProfileUrl());
+		assertEquals("https://twitter.com/kdonald/picture", twitter.getImageUrl());
 		TestTwitterApi twitterApi = twitter.getApi();
 		assertEquals("123456789", twitterApi.getAccessToken());
 		assertEquals("987654321", twitterApi.getSecret());
 		twitter.sync();
-		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
+		assertEquals("https://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
 	}
 
 	private void assertFacebookConnection(Connection<TestFacebookApi> facebook) {
@@ -530,8 +530,8 @@ public class SQLiteUsersConnectionRepositoryTest extends AndroidTestCase {
 		assertEquals("234567890", facebookApi.getAccessToken());
 		facebook.sync();
 		assertEquals("Keith Donald", facebook.getDisplayName());
-		assertEquals("http://facebook.com/keith.donald", facebook.getProfileUrl());
-		assertEquals("http://facebook.com/keith.donald/picture", facebook.getImageUrl());
+		assertEquals("https://facebook.com/keith.donald", facebook.getProfileUrl());
+		assertEquals("https://facebook.com/keith.donald/picture", facebook.getImageUrl());
 	}
 
 	// test facebook provider
@@ -603,9 +603,9 @@ public class SQLiteUsersConnectionRepositoryTest extends AndroidTestCase {
 
 		private String name = "Keith Donald";
 
-		private String profileUrl = "http://facebook.com/keith.donald";
+		private String profileUrl = "https://facebook.com/keith.donald";
 
-		private String profilePictureUrl = "http://facebook.com/keith.donald/picture";
+		private String profilePictureUrl = "https://facebook.com/keith.donald/picture";
 
 		public boolean test(TestFacebookApi api) {
 			return true;
@@ -672,9 +672,9 @@ public class SQLiteUsersConnectionRepositoryTest extends AndroidTestCase {
 
 		private String name = "@kdonald";
 
-		private String profileUrl = "http://twitter.com/kdonald";
+		private String profileUrl = "https://twitter.com/kdonald";
 
-		private String profilePictureUrl = "http://twitter.com/kdonald/a_new_picture";
+		private String profilePictureUrl = "https://twitter.com/kdonald/a_new_picture";
 
 		public boolean test(TestTwitterApi api) {
 			return true;

--- a/test/spring-android-core-test/src/main/java/org/springframework/core/io/ResourceTests.java
+++ b/test/spring-android-core-test/src/main/java/org/springframework/core/io/ResourceTests.java
@@ -146,7 +146,7 @@ public class ResourceTests extends AndroidTestCase {
 	}
 
 //	public void testNonFileResourceExists() throws Exception {
-//		Resource resource = new UrlResource("http://springone2gx.com");
+//		Resource resource = new UrlResource("https://springone2gx.com");
 //		assertTrue(resource.exists());
 //	}
 

--- a/test/spring-android-rest-template-test/src/main/java/org/springframework/http/HttpHeadersTests.java
+++ b/test/spring-android-rest-template-test/src/main/java/org/springframework/http/HttpHeadersTests.java
@@ -128,10 +128,10 @@ public class HttpHeadersTests extends TestCase {
 
 	@SmallTest
 	public void testLocation() throws URISyntaxException {
-		URI location = new URI("http://www.example.com/hotels");
+		URI location = new URI("https://www.example.com/hotels");
 		headers.setLocation(location);
 		assertEquals("Invalid Location header", location, headers.getLocation());
-		assertEquals("Invalid Location header", "http://www.example.com/hotels", headers.getFirst("Location"));
+		assertEquals("Invalid Location header", "https://www.example.com/hotels", headers.getFirst("Location"));
 	}
 
 	@SmallTest

--- a/test/spring-android-rest-template-test/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequestFactoryTests.java
+++ b/test/spring-android-rest-template-test/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequestFactoryTests.java
@@ -30,7 +30,7 @@ public class HttpComponentsClientHttpRequestFactoryTests extends HttpComponentsA
 	}
 
 	public void createHttpUriRequest() throws Exception {
-		URI uri = new URI("http://example.com");
+		URI uri = new URI("https://example.com");
 		confirmRequestBodyAllowed(uri, HttpMethod.GET, false);
 		confirmRequestBodyAllowed(uri, HttpMethod.HEAD, false);
 		confirmRequestBodyAllowed(uri, HttpMethod.OPTIONS, false);

--- a/test/spring-android-rest-template-test/src/main/java/org/springframework/http/client/InterceptingClientHttpRequestFactoryTests.java
+++ b/test/spring-android-rest-template-test/src/main/java/org/springframework/http/client/InterceptingClientHttpRequestFactoryTests.java
@@ -71,7 +71,7 @@ public class InterceptingClientHttpRequestFactoryTests extends TestCase {
 		interceptors.add(new NoOpInterceptor());
 		requestFactory = new InterceptingClientHttpRequestFactory(requestFactoryMock, interceptors);
 
-		ClientHttpRequest request = requestFactory.createRequest(new URI("http://example.com"), HttpMethod.GET);
+		ClientHttpRequest request = requestFactory.createRequest(new URI("https://example.com"), HttpMethod.GET);
 		ClientHttpResponse response = request.execute();
 
 		assertTrue(((NoOpInterceptor) interceptors.get(0)).invoked);
@@ -93,7 +93,7 @@ public class InterceptingClientHttpRequestFactoryTests extends TestCase {
 		interceptors.add(new NoOpInterceptor());
 		requestFactory = new InterceptingClientHttpRequestFactory(requestFactoryMock, interceptors);
 
-		ClientHttpRequest request = requestFactory.createRequest(new URI("http://example.com"), HttpMethod.GET);
+		ClientHttpRequest request = requestFactory.createRequest(new URI("https://example.com"), HttpMethod.GET);
 		ClientHttpResponse response = request.execute();
 
 		assertFalse(((NoOpInterceptor) interceptors.get(1)).invoked);
@@ -129,13 +129,13 @@ public class InterceptingClientHttpRequestFactoryTests extends TestCase {
 
 		requestFactory = new InterceptingClientHttpRequestFactory(requestFactoryMock, Collections.singletonList(interceptor));
 
-		ClientHttpRequest request = requestFactory.createRequest(new URI("http://example.com"), HttpMethod.GET);
+		ClientHttpRequest request = requestFactory.createRequest(new URI("https://example.com"), HttpMethod.GET);
 		request.execute();
 	}
 
 	@MediumTest
 	public void testChangeURI() throws Exception {
-		final URI changedUri = new URI("http://example.com/2");
+		final URI changedUri = new URI("https://example.com/2");
 		ClientHttpRequestInterceptor interceptor = new ClientHttpRequestInterceptor() {
 			public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
 
@@ -159,7 +159,7 @@ public class InterceptingClientHttpRequestFactoryTests extends TestCase {
 
 		requestFactory = new InterceptingClientHttpRequestFactory(requestFactoryMock, Collections.singletonList(interceptor));
 
-		ClientHttpRequest request = requestFactory.createRequest(new URI("http://example.com"), HttpMethod.GET);
+		ClientHttpRequest request = requestFactory.createRequest(new URI("https://example.com"), HttpMethod.GET);
 		request.execute();
 	}
 
@@ -189,7 +189,7 @@ public class InterceptingClientHttpRequestFactoryTests extends TestCase {
 
 		requestFactory = new InterceptingClientHttpRequestFactory(requestFactoryMock, Collections.singletonList(interceptor));
 
-		ClientHttpRequest request = requestFactory.createRequest(new URI("http://example.com"), HttpMethod.GET);
+		ClientHttpRequest request = requestFactory.createRequest(new URI("https://example.com"), HttpMethod.GET);
 		request.execute();
 	}
 
@@ -205,7 +205,7 @@ public class InterceptingClientHttpRequestFactoryTests extends TestCase {
 
 		requestFactory = new InterceptingClientHttpRequestFactory(requestFactoryMock, Collections.singletonList(interceptor));
 
-		ClientHttpRequest request = requestFactory.createRequest(new URI("http://example.com"), HttpMethod.GET);
+		ClientHttpRequest request = requestFactory.createRequest(new URI("https://example.com"), HttpMethod.GET);
 		request.execute();
 		assertTrue(Arrays.equals(changedBody, requestMock.body.toByteArray()));
 	}

--- a/test/spring-android-rest-template-test/src/main/java/org/springframework/http/converter/xml/SourceHttpMessageConverterTests.java
+++ b/test/spring-android-rest-template-test/src/main/java/org/springframework/http/converter/xml/SourceHttpMessageConverterTests.java
@@ -74,7 +74,7 @@ public class SourceHttpMessageConverterTests extends TestCase {
 		if (javaxXmlTransformPresent) {
 			this.converter = new SourceHttpMessageConverter<Source>();
 			Resource external = new ClassPathResource("external.txt", getClass());
-			bodyExternal = "<!DOCTYPE root SYSTEM \"http://192.168.28.42/1.jsp\" [" +
+			bodyExternal = "<!DOCTYPE root SYSTEM \"https://192.168.28.42/1.jsp\" [" +
 					"  <!ELEMENT root ANY >\n" +
 					"  <!ENTITY ext SYSTEM \"" + external.getURI() + "\" >]><root>&ext;</root>";
 		}

--- a/test/spring-android-rest-template-test/src/main/java/org/springframework/web/client/RestTemplateTests.java
+++ b/test/spring-android-rest-template-test/src/main/java/org/springframework/web/client/RestTemplateTests.java
@@ -74,7 +74,7 @@ public class RestTemplateTests extends TestCase {
 	}
 
 	public void testVarArgsTemplateVariables() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com/hotels/42/bookings/21"), HttpMethod.GET))
+		given(requestFactory.createRequest(new URI("https://example.com/hotels/42/bookings/21"), HttpMethod.GET))
 				.willReturn(request);
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(false);
@@ -82,14 +82,14 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		template.execute("http://example.com/hotels/{hotel}/bookings/{booking}", HttpMethod.GET, null, null, "42",
+		template.execute("https://example.com/hotels/{hotel}/bookings/{booking}", HttpMethod.GET, null, null, "42",
 				"21");
 
 		verify(response).close();
 	}
 
 	public void testVarArgsNullTemplateVariable() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com/-foo"), HttpMethod.GET))
+		given(requestFactory.createRequest(new URI("https://example.com/-foo"), HttpMethod.GET))
 				.willReturn(request);
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(false);
@@ -97,13 +97,13 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		template.execute("http://example.com/{first}-{last}", HttpMethod.GET, null, null, null, "foo");
+		template.execute("https://example.com/{first}-{last}", HttpMethod.GET, null, null, null, "foo");
 
 		verify(response).close();
 	}
 
 	public void testMapTemplateVariables() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com/hotels/42/bookings/42"), HttpMethod.GET))
+		given(requestFactory.createRequest(new URI("https://example.com/hotels/42/bookings/42"), HttpMethod.GET))
 				.willReturn(request);
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(false);
@@ -112,13 +112,13 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
 		Map<String, String> vars = Collections.singletonMap("hotel", "42");
-		template.execute("http://example.com/hotels/{hotel}/bookings/{hotel}", HttpMethod.GET, null, null, vars);
+		template.execute("https://example.com/hotels/{hotel}/bookings/{hotel}", HttpMethod.GET, null, null, vars);
 
 		verify(response).close();
 	}
 
 	public void testMapNullTemplateVariable() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com/-foo"), HttpMethod.GET))
+		given(requestFactory.createRequest(new URI("https://example.com/-foo"), HttpMethod.GET))
 				.willReturn(request);
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(false);
@@ -129,13 +129,13 @@ public class RestTemplateTests extends TestCase {
 		Map<String, String> vars = new HashMap<String, String>(2);
 		vars.put("first", null);
 		vars.put("last", "foo");
-		template.execute("http://example.com/{first}-{last}", HttpMethod.GET, null, null, vars);
+		template.execute("https://example.com/{first}-{last}", HttpMethod.GET, null, null, vars);
 
 		verify(response).close();
 	}
 
 	public void testErrorHandling() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.GET)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.GET)).willReturn(request);
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(true);
 		given(response.getStatusCode()).willReturn(HttpStatus.INTERNAL_SERVER_ERROR);
@@ -143,7 +143,7 @@ public class RestTemplateTests extends TestCase {
 		willThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR)).given(errorHandler).handleError(response);
 
 		try {
-			template.execute("http://example.com", HttpMethod.GET, null, null);
+			template.execute("https://example.com", HttpMethod.GET, null, null);
 			fail("HttpServerErrorException expected");
 		}
 		catch (HttpServerErrorException ex) {
@@ -157,7 +157,7 @@ public class RestTemplateTests extends TestCase {
 		given(converter.canRead(String.class, null)).willReturn(true);
 		MediaType textPlain = new MediaType("text", "plain");
 		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(textPlain));
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.GET)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.GET)).willReturn(request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(request.getHeaders()).willReturn(requestHeaders);
 		given(request.execute()).willReturn(response);
@@ -174,7 +174,7 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		String result = template.getForObject("http://example.com", String.class);
+		String result = template.getForObject("https://example.com", String.class);
 		assertEquals("Invalid GET result", expected, result);
 		assertEquals("Invalid Accept header", textPlain.toString(), requestHeaders.getFirst("Accept"));
 
@@ -185,7 +185,7 @@ public class RestTemplateTests extends TestCase {
 		given(converter.canRead(String.class, null)).willReturn(true);
 		MediaType supportedMediaType = new MediaType("foo", "bar");
 		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(supportedMediaType));
-		given(requestFactory.createRequest(new URI("http://example.com/resource"), HttpMethod.GET)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com/resource"), HttpMethod.GET)).willReturn(request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(request.getHeaders()).willReturn(requestHeaders);
 		given(request.execute()).willReturn(response);
@@ -202,7 +202,7 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
 		try {
-			template.getForObject("http://example.com/{p}", String.class, "resource");
+			template.getForObject("https://example.com/{p}", String.class, "resource");
 			fail("UnsupportedMediaTypeException expected");
 		}
 		catch (RestClientException ex) {
@@ -216,7 +216,7 @@ public class RestTemplateTests extends TestCase {
 		given(converter.canRead(String.class, null)).willReturn(true);
 		MediaType textPlain = new MediaType("text", "plain");
 		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(textPlain));
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.GET)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.GET)).willReturn(request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(request.getHeaders()).willReturn(requestHeaders);
 		given(request.execute()).willReturn(response);
@@ -234,7 +234,7 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		ResponseEntity<String> result = template.getForEntity("http://example.com", String.class);
+		ResponseEntity<String> result = template.getForEntity("https://example.com", String.class);
 		assertEquals("Invalid GET result", expected, result.getBody());
 		assertEquals("Invalid Accept header", textPlain.toString(), requestHeaders.getFirst("Accept"));
 		assertEquals("Invalid Content-Type header", textPlain, result.getHeaders().getContentType());
@@ -244,7 +244,7 @@ public class RestTemplateTests extends TestCase {
 	}
 
 	public void testHeadForHeaders() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.HEAD)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.HEAD)).willReturn(request);
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(false);
 		HttpHeaders responseHeaders = new HttpHeaders();
@@ -253,7 +253,7 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		HttpHeaders result = template.headForHeaders("http://example.com");
+		HttpHeaders result = template.headForHeaders("https://example.com");
 
 		assertSame("Invalid headers returned", responseHeaders, result);
 
@@ -261,28 +261,28 @@ public class RestTemplateTests extends TestCase {
 	}
 
 	public void testPostForLocation() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(request);
 		String helloWorld = "Hello World";
 		given(converter.canWrite(String.class, null)).willReturn(true);
 		converter.write(helloWorld, null, request);
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(false);
 		HttpHeaders responseHeaders = new HttpHeaders();
-		URI expected = new URI("http://example.com/hotels");
+		URI expected = new URI("https://example.com/hotels");
 		responseHeaders.setLocation(expected);
 		given(response.getHeaders()).willReturn(responseHeaders);
 		HttpStatus status = HttpStatus.OK;
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		URI result = template.postForLocation("http://example.com", helloWorld);
+		URI result = template.postForLocation("https://example.com", helloWorld);
 		assertEquals("Invalid POST result", expected, result);
 
 		verify(response).close();
 	}
 
 	public void testPostForLocationEntityContentType() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(request);
 		String helloWorld = "Hello World";
 		MediaType contentType = MediaType.TEXT_PLAIN;
 		given(converter.canWrite(String.class, contentType)).willReturn(true);
@@ -292,7 +292,7 @@ public class RestTemplateTests extends TestCase {
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(false);
 		HttpHeaders responseHeaders = new HttpHeaders();
-		URI expected = new URI("http://example.com/hotels");
+		URI expected = new URI("https://example.com/hotels");
 		responseHeaders.setLocation(expected);
 		given(response.getHeaders()).willReturn(responseHeaders);
 		HttpStatus status = HttpStatus.OK;
@@ -303,14 +303,14 @@ public class RestTemplateTests extends TestCase {
 		entityHeaders.setContentType(contentType);
 		HttpEntity<String> entity = new HttpEntity<String>(helloWorld, entityHeaders);
 
-		URI result = template.postForLocation("http://example.com", entity);
+		URI result = template.postForLocation("https://example.com", entity);
 		assertEquals("Invalid POST result", expected, result);
 
 		verify(response).close();
 	}
 
 	public void testPostForLocationEntityCustomHeader() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(request);
 		String helloWorld = "Hello World";
 		given(converter.canWrite(String.class, null)).willReturn(true);
 		HttpHeaders requestHeaders = new HttpHeaders();
@@ -319,7 +319,7 @@ public class RestTemplateTests extends TestCase {
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(false);
 		HttpHeaders responseHeaders = new HttpHeaders();
-		URI expected = new URI("http://example.com/hotels");
+		URI expected = new URI("https://example.com/hotels");
 		responseHeaders.setLocation(expected);
 		given(response.getHeaders()).willReturn(responseHeaders);
 		HttpStatus status = HttpStatus.OK;
@@ -330,7 +330,7 @@ public class RestTemplateTests extends TestCase {
 		entityHeaders.set("MyHeader", "MyValue");
 		HttpEntity<String> entity = new HttpEntity<String>(helloWorld, entityHeaders);
 
-		URI result = template.postForLocation("http://example.com", entity);
+		URI result = template.postForLocation("https://example.com", entity);
 		assertEquals("Invalid POST result", expected, result);
 		assertEquals("No custom header set", "MyValue", requestHeaders.getFirst("MyHeader"));
 
@@ -338,7 +338,7 @@ public class RestTemplateTests extends TestCase {
 	}
 
 	public void testPostForLocationNoLocation() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(request);
 		String helloWorld = "Hello World";
 		given(converter.canWrite(String.class, null)).willReturn(true);
 		converter.write(helloWorld, null, request);
@@ -350,14 +350,14 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		URI result = template.postForLocation("http://example.com", helloWorld);
+		URI result = template.postForLocation("https://example.com", helloWorld);
 		assertNull("Invalid POST result", result);
 
 		verify(response).close();
 	}
 
 	public void testPostForLocationNull() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(request.getHeaders()).willReturn(requestHeaders);
 		given(request.execute()).willReturn(response);
@@ -368,7 +368,7 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		template.postForLocation("http://example.com", null);
+		template.postForLocation("https://example.com", null);
 		assertEquals("Invalid content length", 0, requestHeaders.getContentLength());
 
 		verify(response).close();
@@ -378,7 +378,7 @@ public class RestTemplateTests extends TestCase {
 		MediaType textPlain = new MediaType("text", "plain");
 		given(converter.canRead(Integer.class, null)).willReturn(true);
 		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(textPlain));
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(this.request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(this.request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(this.request.getHeaders()).willReturn(requestHeaders);
 		String request = "Hello World";
@@ -398,7 +398,7 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		Integer result = template.postForObject("http://example.com", request, Integer.class);
+		Integer result = template.postForObject("https://example.com", request, Integer.class);
 		assertEquals("Invalid POST result", expected, result);
 		assertEquals("Invalid Accept header", textPlain.toString(), requestHeaders.getFirst("Accept"));
 
@@ -409,7 +409,7 @@ public class RestTemplateTests extends TestCase {
 		MediaType textPlain = new MediaType("text", "plain");
 		given(converter.canRead(Integer.class, null)).willReturn(true);
 		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(textPlain));
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(this.request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(this.request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(this.request.getHeaders()).willReturn(requestHeaders);
 		String request = "Hello World";
@@ -430,7 +430,7 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		ResponseEntity<Integer> result = template.postForEntity("http://example.com", request, Integer.class);
+		ResponseEntity<Integer> result = template.postForEntity("https://example.com", request, Integer.class);
 		assertEquals("Invalid POST result", expected, result.getBody());
 		assertEquals("Invalid Content-Type", textPlain, result.getHeaders().getContentType());
 		assertEquals("Invalid Accept header", textPlain.toString(), requestHeaders.getFirst("Accept"));
@@ -443,7 +443,7 @@ public class RestTemplateTests extends TestCase {
 		MediaType textPlain = new MediaType("text", "plain");
 		given(converter.canRead(Integer.class, null)).willReturn(true);
 		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(textPlain));
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(request.getHeaders()).willReturn(requestHeaders);
 		given(request.execute()).willReturn(response);
@@ -459,7 +459,7 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		Integer result = template.postForObject("http://example.com", null, Integer.class);
+		Integer result = template.postForObject("https://example.com", null, Integer.class);
 		assertNull("Invalid POST result", result);
 		assertEquals("Invalid content length", 0, requestHeaders.getContentLength());
 
@@ -470,7 +470,7 @@ public class RestTemplateTests extends TestCase {
 		MediaType textPlain = new MediaType("text", "plain");
 		given(converter.canRead(Integer.class, null)).willReturn(true);
 		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(textPlain));
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(request.getHeaders()).willReturn(requestHeaders);
 		given(request.execute()).willReturn(response);
@@ -487,7 +487,7 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		ResponseEntity<Integer> result = template.postForEntity("http://example.com", null, Integer.class);
+		ResponseEntity<Integer> result = template.postForEntity("https://example.com", null, Integer.class);
 		assertFalse("Invalid POST result", result.hasBody());
 		assertEquals("Invalid Content-Type", textPlain, result.getHeaders().getContentType());
 		assertEquals("Invalid content length", 0, requestHeaders.getContentLength());
@@ -498,7 +498,7 @@ public class RestTemplateTests extends TestCase {
 
 	public void testPut() throws Exception {
 		given(converter.canWrite(String.class, null)).willReturn(true);
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.PUT)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.PUT)).willReturn(request);
 		String helloWorld = "Hello World";
 		converter.write(helloWorld, null, request);
 		given(request.execute()).willReturn(response);
@@ -507,13 +507,13 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		template.put("http://example.com", helloWorld);
+		template.put("https://example.com", helloWorld);
 
 		verify(response).close();
 	}
 
 	public void testPutNull() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.PUT)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.PUT)).willReturn(request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(request.getHeaders()).willReturn(requestHeaders);
 		given(request.execute()).willReturn(response);
@@ -522,27 +522,27 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		template.put("http://example.com", null);
+		template.put("https://example.com", null);
 		assertEquals("Invalid content length", 0, requestHeaders.getContentLength());
 
 		verify(response).close();
 	}
 
 	public void testDelete() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.DELETE)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.DELETE)).willReturn(request);
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(false);
 		HttpStatus status = HttpStatus.OK;
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		template.delete("http://example.com");
+		template.delete("https://example.com");
 
 		verify(response).close();
 	}
 
 	public void testPptionsForAllow() throws Exception {
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.OPTIONS)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.OPTIONS)).willReturn(request);
 		given(request.execute()).willReturn(response);
 		given(errorHandler.hasError(response)).willReturn(false);
 		HttpHeaders responseHeaders = new HttpHeaders();
@@ -553,7 +553,7 @@ public class RestTemplateTests extends TestCase {
 		given(response.getStatusCode()).willReturn(status);
 		given(response.getStatusText()).willReturn(status.getReasonPhrase());
 
-		Set<HttpMethod> result = template.optionsForAllow("http://example.com");
+		Set<HttpMethod> result = template.optionsForAllow("https://example.com");
 		assertEquals("Invalid OPTIONS result", expected, result);
 
 		verify(response).close();
@@ -563,12 +563,12 @@ public class RestTemplateTests extends TestCase {
 		given(converter.canRead(String.class, null)).willReturn(true);
 		MediaType mediaType = new MediaType("foo", "bar");
 		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(mediaType));
-		given(requestFactory.createRequest(new URI("http://example.com/resource"), HttpMethod.GET)).willReturn(request);
+		given(requestFactory.createRequest(new URI("https://example.com/resource"), HttpMethod.GET)).willReturn(request);
 		given(request.getHeaders()).willReturn(new HttpHeaders());
 		given(request.execute()).willThrow(new IOException());
 
 		try {
-			template.getForObject("http://example.com/resource", String.class);
+			template.getForObject("https://example.com/resource", String.class);
 			fail("RestClientException expected");
 		}
 		catch (ResourceAccessException ex) {
@@ -579,7 +579,7 @@ public class RestTemplateTests extends TestCase {
 	public void testExchange() throws Exception {
 		given(converter.canRead(Integer.class, null)).willReturn(true);
 		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(MediaType.TEXT_PLAIN));
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(this.request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(this.request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(this.request.getHeaders()).willReturn(requestHeaders);
 		given(converter.canWrite(String.class, null)).willReturn(true);
@@ -603,7 +603,7 @@ public class RestTemplateTests extends TestCase {
 		HttpHeaders entityHeaders = new HttpHeaders();
 		entityHeaders.set("MyHeader", "MyValue");
 		HttpEntity<String> requestEntity = new HttpEntity<String>(body, entityHeaders);
-		ResponseEntity<Integer> result = template.exchange("http://example.com", HttpMethod.POST, requestEntity, Integer.class);
+		ResponseEntity<Integer> result = template.exchange("https://example.com", HttpMethod.POST, requestEntity, Integer.class);
 		assertEquals("Invalid POST result", expected, result.getBody());
 		assertEquals("Invalid Content-Type", MediaType.TEXT_PLAIN, result.getHeaders().getContentType());
 		assertEquals("Invalid Accept header", MediaType.TEXT_PLAIN_VALUE, requestHeaders.getFirst("Accept"));
@@ -620,7 +620,7 @@ public class RestTemplateTests extends TestCase {
 		ParameterizedTypeReference<List<Integer>> intList = new ParameterizedTypeReference<List<Integer>>() {};
 		given(converter.canRead(intList.getType(), null, null)).willReturn(true);
 		given(converter.getSupportedMediaTypes()).willReturn(Collections.singletonList(MediaType.TEXT_PLAIN));
-		given(requestFactory.createRequest(new URI("http://example.com"), HttpMethod.POST)).willReturn(this.request);
+		given(requestFactory.createRequest(new URI("https://example.com"), HttpMethod.POST)).willReturn(this.request);
 		HttpHeaders requestHeaders = new HttpHeaders();
 		given(this.request.getHeaders()).willReturn(requestHeaders);
 		given(converter.canWrite(String.class, null)).willReturn(true);
@@ -644,7 +644,7 @@ public class RestTemplateTests extends TestCase {
 		HttpHeaders entityHeaders = new HttpHeaders();
 		entityHeaders.set("MyHeader", "MyValue");
 		HttpEntity<String> requestEntity = new HttpEntity<String>(requestBody, entityHeaders);
-		ResponseEntity<List<Integer>> result = template.exchange("http://example.com", HttpMethod.POST, requestEntity, intList);
+		ResponseEntity<List<Integer>> result = template.exchange("https://example.com", HttpMethod.POST, requestEntity, intList);
 		assertEquals("Invalid POST result", expected, result.getBody());
 		assertEquals("Invalid Content-Type", MediaType.TEXT_PLAIN, result.getHeaders().getContentType());
 		assertEquals("Invalid Accept header", MediaType.TEXT_PLAIN_VALUE, requestHeaders.getFirst("Accept"));

--- a/test/spring-android-rest-template-test/src/main/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/test/spring-android-rest-template-test/src/main/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -51,7 +51,7 @@ public class UriComponentsBuilderTests extends TestCase {
 		assertEquals("bar", result.getQuery());
 		assertEquals("baz", result.getFragment());
 
-		URI expected = new URI("http://example.com/foo?bar#baz");
+		URI expected = new URI("https://example.com/foo?bar#baz");
 		assertEquals("Invalid result URI", expected, result.toUri());
 	}
 
@@ -65,7 +65,7 @@ public class UriComponentsBuilderTests extends TestCase {
 		assertEquals("http", result1.getScheme());
 		assertEquals("example.com", result1.getHost());
 		assertEquals("/foo", result1.getPath());
-		URI expected = new URI("http://example.com/foo");
+		URI expected = new URI("https://example.com/foo");
 		assertEquals("Invalid result URI", expected, result1.toUri());
 
 		assertEquals("http", result2.getScheme());
@@ -73,7 +73,7 @@ public class UriComponentsBuilderTests extends TestCase {
 		assertEquals("/foo/foo2", result2.getPath());
 		assertEquals("bar", result2.getQuery());
 		assertEquals("baz", result2.getFragment());
-		expected = new URI("http://example.com/foo/foo2?bar#baz");
+		expected = new URI("https://example.com/foo/foo2?bar#baz");
 		assertEquals("Invalid result URI", expected, result2.toUri());
 	}
 
@@ -98,7 +98,7 @@ public class UriComponentsBuilderTests extends TestCase {
 
 	@SmallTest
 	public void testFromHierarchicalUri() throws URISyntaxException {
-		URI uri = new URI("http://example.com/foo?bar#baz");
+		URI uri = new URI("https://example.com/foo?bar#baz");
 		UriComponents result = UriComponentsBuilder.fromUri(uri).build();
 		assertEquals("http", result.getScheme());
 		assertEquals("example.com", result.getHost());
@@ -124,7 +124,7 @@ public class UriComponentsBuilderTests extends TestCase {
 
 	@SmallTest
 	public void testFromUriEncodedQuery() throws URISyntaxException {
-		URI uri = new URI("http://www.example.org/?param=aGVsbG9Xb3JsZA%3D%3D");
+		URI uri = new URI("https://www.example.org/?param=aGVsbG9Xb3JsZA%3D%3D");
 		String fromUri = UriComponentsBuilder.fromUri(uri).build().getQueryParams().get("param").get(0);
 		String fromUriString = UriComponentsBuilder.fromUriString(uri.toString()).build().getQueryParams().get("param").get(0);
 
@@ -133,7 +133,7 @@ public class UriComponentsBuilderTests extends TestCase {
 
 	@SmallTest
 	public void testFromUriString() {
-		UriComponents result = UriComponentsBuilder.fromUriString("http://www.ietf.org/rfc/rfc3986.txt").build();
+		UriComponents result = UriComponentsBuilder.fromUriString("https://www.ietf.org/rfc/rfc3986.txt").build();
 		assertEquals("http", result.getScheme());
 		assertNull(result.getUserInfo());
 		assertEquals("www.ietf.org", result.getHost());
@@ -144,7 +144,7 @@ public class UriComponentsBuilderTests extends TestCase {
 		assertNull(result.getFragment());
 
 		result = UriComponentsBuilder.fromUriString(
-				"http://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar#and(java.util.BitSet)")
+				"https://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar#and(java.util.BitSet)")
 				.build();
 		assertEquals("http", result.getScheme());
 		assertEquals("arjen:foobar", result.getUserInfo());
@@ -181,7 +181,7 @@ public class UriComponentsBuilderTests extends TestCase {
 
 	@SmallTest
 	public void testFromUriStringQueryParamWithReservedCharInValue() throws URISyntaxException {
-		String uri = "http://www.google.com/ig/calculator?q=1USD=?EUR";
+		String uri = "https://www.google.com/ig/calculator?q=1USD=?EUR";
 		UriComponents result = UriComponentsBuilder.fromUriString(uri).build();
 
 		assertEquals("q=1USD=?EUR", result.getQuery());
@@ -230,7 +230,7 @@ public class UriComponentsBuilderTests extends TestCase {
 
 	@SmallTest
 	public void testFromUriStringNoPathWithReservedCharInQuery() {
-		UriComponents result = UriComponentsBuilder.fromUriString("http://example.com?foo=bar@baz").build();
+		UriComponents result = UriComponentsBuilder.fromUriString("https://example.com?foo=bar@baz").build();
 		assertTrue(StringUtils.isEmpty(result.getUserInfo()));
 		assertEquals("example.com", result.getHost());
 		assertTrue(result.getQueryParams().containsKey("foo"));
@@ -310,32 +310,32 @@ public class UriComponentsBuilderTests extends TestCase {
 
 	@SmallTest
 	public void testReplacePath() {
-		UriComponentsBuilder builder = UriComponentsBuilder.fromUriString("http://www.ietf.org/rfc/rfc2396.txt");
+		UriComponentsBuilder builder = UriComponentsBuilder.fromUriString("https://www.ietf.org/rfc/rfc2396.txt");
 		builder.replacePath("/rfc/rfc3986.txt");
 		UriComponents result = builder.build();
 
-		assertEquals("http://www.ietf.org/rfc/rfc3986.txt", result.toUriString());
+		assertEquals("https://www.ietf.org/rfc/rfc3986.txt", result.toUriString());
 
-		builder = UriComponentsBuilder.fromUriString("http://www.ietf.org/rfc/rfc2396.txt");
+		builder = UriComponentsBuilder.fromUriString("https://www.ietf.org/rfc/rfc2396.txt");
 		builder.replacePath(null);
 		result = builder.build();
 
-		assertEquals("http://www.ietf.org", result.toUriString());
+		assertEquals("https://www.ietf.org", result.toUriString());
 	}
 
 	@SmallTest
 	public void testReplaceQuery() {
-		UriComponentsBuilder builder = UriComponentsBuilder.fromUriString("http://example.com/foo?foo=bar&baz=qux");
+		UriComponentsBuilder builder = UriComponentsBuilder.fromUriString("https://example.com/foo?foo=bar&baz=qux");
 		builder.replaceQuery("baz=42");
 		UriComponents result = builder.build();
 
-		assertEquals("http://example.com/foo?baz=42", result.toUriString());
+		assertEquals("https://example.com/foo?baz=42", result.toUriString());
 
-		builder = UriComponentsBuilder.fromUriString("http://example.com/foo?foo=bar&baz=qux");
+		builder = UriComponentsBuilder.fromUriString("https://example.com/foo?foo=bar&baz=qux");
 		builder.replaceQuery(null);
 		result = builder.build();
 
-		assertEquals("http://example.com/foo", result.toUriString());
+		assertEquals("https://example.com/foo", result.toUriString());
 	}
 
 	@SmallTest
@@ -402,41 +402,41 @@ public class UriComponentsBuilderTests extends TestCase {
 
 	@SmallTest
 	public void testQueryParamWithValueWithEquals() throws Exception {
-		UriComponents uriComponents = UriComponentsBuilder.fromUriString("http://example.com/foo?bar=baz").build();
-		assertThat(uriComponents.toUriString(), equalTo("http://example.com/foo?bar=baz"));
+		UriComponents uriComponents = UriComponentsBuilder.fromUriString("https://example.com/foo?bar=baz").build();
+		assertThat(uriComponents.toUriString(), equalTo("https://example.com/foo?bar=baz"));
 	}
 
 	@SmallTest
 	public void testQueryParamWithoutValueWithEquals() throws Exception {
-		UriComponents uriComponents = UriComponentsBuilder.fromUriString("http://example.com/foo?bar=").build();
-		assertThat(uriComponents.toUriString(), equalTo("http://example.com/foo?bar="));
+		UriComponents uriComponents = UriComponentsBuilder.fromUriString("https://example.com/foo?bar=").build();
+		assertThat(uriComponents.toUriString(), equalTo("https://example.com/foo?bar="));
 	}
 
 	@SmallTest
 	public void testQueryParamWithoutValueWithoutEquals() throws Exception {
-		UriComponents uriComponents = UriComponentsBuilder.fromUriString("http://example.com/foo?bar").build();
-		assertThat(uriComponents.toUriString(), equalTo("http://example.com/foo?bar"));
+		UriComponents uriComponents = UriComponentsBuilder.fromUriString("https://example.com/foo?bar").build();
+		assertThat(uriComponents.toUriString(), equalTo("https://example.com/foo?bar"));
 	}
 
 	@SmallTest
 	public void testRelativeUrls() throws Exception {
-		assertThat(UriComponentsBuilder.fromUriString("http://example.com/foo/../bar").build().toString(), equalTo("http://example.com/foo/../bar"));
-		assertThat(UriComponentsBuilder.fromUriString("http://example.com/foo/../bar").build().toUriString(), equalTo("http://example.com/foo/../bar"));
-		assertThat(UriComponentsBuilder.fromUriString("http://example.com/foo/../bar").build().toUri().getPath(), equalTo("/foo/../bar"));
+		assertThat(UriComponentsBuilder.fromUriString("https://example.com/foo/../bar").build().toString(), equalTo("https://example.com/foo/../bar"));
+		assertThat(UriComponentsBuilder.fromUriString("https://example.com/foo/../bar").build().toUriString(), equalTo("https://example.com/foo/../bar"));
+		assertThat(UriComponentsBuilder.fromUriString("https://example.com/foo/../bar").build().toUri().getPath(), equalTo("/foo/../bar"));
 		assertThat(UriComponentsBuilder.fromUriString("../../").build().toString(), equalTo("../../"));
 		assertThat(UriComponentsBuilder.fromUriString("../../").build().toUriString(), equalTo("../../"));
 		assertThat(UriComponentsBuilder.fromUriString("../../").build().toUri().getPath(), equalTo("../../"));
-		assertThat(UriComponentsBuilder.fromUriString("http://example.com").path("foo/../bar").build().toString(), equalTo("http://example.com/foo/../bar"));
-		assertThat(UriComponentsBuilder.fromUriString("http://example.com").path("foo/../bar").build().toUriString(), equalTo("http://example.com/foo/../bar"));
-		assertThat(UriComponentsBuilder.fromUriString("http://example.com").path("foo/../bar").build().toUri().getPath(), equalTo("/foo/../bar"));
+		assertThat(UriComponentsBuilder.fromUriString("https://example.com").path("foo/../bar").build().toString(), equalTo("https://example.com/foo/../bar"));
+		assertThat(UriComponentsBuilder.fromUriString("https://example.com").path("foo/../bar").build().toUriString(), equalTo("https://example.com/foo/../bar"));
+		assertThat(UriComponentsBuilder.fromUriString("https://example.com").path("foo/../bar").build().toUri().getPath(), equalTo("/foo/../bar"));
 	}
 
 	@SmallTest
 	public void testEmptySegments() throws Exception {
-		assertThat(UriComponentsBuilder.fromUriString("http://example.com/abc/").path("/x/y/z").build().toString(), equalTo("http://example.com/abc/x/y/z"));
-		assertThat(UriComponentsBuilder.fromUriString("http://example.com/abc/").pathSegment("x", "y", "z").build().toString(), equalTo("http://example.com/abc/x/y/z"));
-		assertThat(UriComponentsBuilder.fromUriString("http://example.com/abc/").path("/x/").path("/y/z").build().toString(), equalTo("http://example.com/abc/x/y/z"));
-		assertThat(UriComponentsBuilder.fromUriString("http://example.com/abc/").pathSegment("x").path("y").build().toString(), equalTo("http://example.com/abc/x/y"));
+		assertThat(UriComponentsBuilder.fromUriString("https://example.com/abc/").path("/x/y/z").build().toString(), equalTo("https://example.com/abc/x/y/z"));
+		assertThat(UriComponentsBuilder.fromUriString("https://example.com/abc/").pathSegment("x", "y", "z").build().toString(), equalTo("https://example.com/abc/x/y/z"));
+		assertThat(UriComponentsBuilder.fromUriString("https://example.com/abc/").path("/x/").path("/y/z").build().toString(), equalTo("https://example.com/abc/x/y/z"));
+		assertThat(UriComponentsBuilder.fromUriString("https://example.com/abc/").pathSegment("x").path("y").build().toString(), equalTo("https://example.com/abc/x/y"));
 	}
 
 	@SmallTest

--- a/test/spring-android-rest-template-test/src/main/java/org/springframework/web/util/UriComponentsTests.java
+++ b/test/spring-android-rest-template-test/src/main/java/org/springframework/web/util/UriComponentsTests.java
@@ -45,23 +45,23 @@ public class UriComponentsTests extends TestCase {
 	@SmallTest
 	public void testToUriEncoded() throws URISyntaxException {
 		UriComponents uriComponents = UriComponentsBuilder.fromUriString(
-				"http://example.com/hotel list/Z\u00fcrich").build();
-		assertEquals(new URI("http://example.com/hotel%20list/Z%C3%BCrich"), uriComponents.encode().toUri());
+				"https://example.com/hotel list/Z\u00fcrich").build();
+		assertEquals(new URI("https://example.com/hotel%20list/Z%C3%BCrich"), uriComponents.encode().toUri());
 	}
 
 	@SmallTest
 	public void testToUriNotEncoded() throws URISyntaxException {
 		UriComponents uriComponents = UriComponentsBuilder.fromUriString(
-				"http://example.com/hotel list/Z\u00fcrich").build();
-		assertEquals(new URI("http://example.com/hotel%20list/Z\u00fcrich"), uriComponents.toUri());
+				"https://example.com/hotel list/Z\u00fcrich").build();
+		assertEquals(new URI("https://example.com/hotel%20list/Z\u00fcrich"), uriComponents.toUri());
 	}
 
 	@SmallTest
 	public void testToUriAlreadyEncoded() throws URISyntaxException {
 		UriComponents uriComponents = UriComponentsBuilder.fromUriString(
-				"http://example.com/hotel%20list/Z%C3%BCrich").build(true);
+				"https://example.com/hotel%20list/Z%C3%BCrich").build(true);
 		UriComponents encoded = uriComponents.encode();
-		assertEquals(new URI("http://example.com/hotel%20list/Z%C3%BCrich"), encoded.toUri());
+		assertEquals(new URI("https://example.com/hotel%20list/Z%C3%BCrich"), encoded.toUri());
 	}
 
 	@SmallTest
@@ -75,28 +75,28 @@ public class UriComponentsTests extends TestCase {
 	@SmallTest
 	public void testExpand() {
 		UriComponents uriComponents = UriComponentsBuilder.fromUriString(
-				"http://example.com").path("/{foo} {bar}").build();
+				"https://example.com").path("/{foo} {bar}").build();
 		uriComponents = uriComponents.expand("1 2", "3 4");
 		assertEquals("/1 2 3 4", uriComponents.getPath());
-		assertEquals("http://example.com/1 2 3 4", uriComponents.toUriString());
+		assertEquals("https://example.com/1 2 3 4", uriComponents.toUriString());
 	}
 
 	// SPR-12123
 
 	@SmallTest
 	public void port() {
-		UriComponents uri1 = UriComponentsBuilder.fromUriString("http://example.com:8080/bar").build();
-		UriComponents uri2 = UriComponentsBuilder.fromUriString("http://example.com/bar").port(8080).build();
-		UriComponents uri3 = UriComponentsBuilder.fromUriString("http://example.com/bar").port("{port}").build().expand(8080);
-		UriComponents uri4 = UriComponentsBuilder.fromUriString("http://example.com/bar").port("808{digit}").build().expand(0);
+		UriComponents uri1 = UriComponentsBuilder.fromUriString("https://example.com:8080/bar").build();
+		UriComponents uri2 = UriComponentsBuilder.fromUriString("https://example.com/bar").port(8080).build();
+		UriComponents uri3 = UriComponentsBuilder.fromUriString("https://example.com/bar").port("{port}").build().expand(8080);
+		UriComponents uri4 = UriComponentsBuilder.fromUriString("https://example.com/bar").port("808{digit}").build().expand(0);
 		assertEquals(8080, uri1.getPort());
-		assertEquals("http://example.com:8080/bar", uri1.toUriString());
+		assertEquals("https://example.com:8080/bar", uri1.toUriString());
 		assertEquals(8080, uri2.getPort());
-		assertEquals("http://example.com:8080/bar", uri2.toUriString());
+		assertEquals("https://example.com:8080/bar", uri2.toUriString());
 		assertEquals(8080, uri3.getPort());
-		assertEquals("http://example.com:8080/bar", uri3.toUriString());
+		assertEquals("https://example.com:8080/bar", uri3.toUriString());
 		assertEquals(8080, uri4.getPort());
-		assertEquals("http://example.com:8080/bar", uri4.toUriString());
+		assertEquals("https://example.com:8080/bar", uri4.toUriString());
 	}
 
 	@SmallTest
@@ -128,14 +128,14 @@ public class UriComponentsTests extends TestCase {
 
 	@SmallTest
 	public void testNormalize() {
-		UriComponents uriComponents = UriComponentsBuilder.fromUriString("http://example.com/foo/../bar").build();
-		assertEquals("http://example.com/bar", uriComponents.normalize().toString());
+		UriComponents uriComponents = UriComponentsBuilder.fromUriString("https://example.com/foo/../bar").build();
+		assertEquals("https://example.com/bar", uriComponents.normalize().toString());
 	}
 
 	@SmallTest
 	public void testSerializable() throws Exception {
 		UriComponents uriComponents = UriComponentsBuilder.fromUriString(
-				"http://example.com").path("/{foo}").query("bar={baz}").build();
+				"https://example.com").path("/{foo}").query("bar={baz}").build();
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		ObjectOutputStream oos = new ObjectOutputStream(bos);
 		oos.writeObject(uriComponents);
@@ -146,9 +146,9 @@ public class UriComponentsTests extends TestCase {
 
 	@SmallTest
 	public void testEqualsHierarchicalUriComponents() throws Exception {
-		UriComponents uriComponents1 = UriComponentsBuilder.fromUriString("http://example.com").path("/{foo}").query("bar={baz}").build();
-		UriComponents uriComponents2 = UriComponentsBuilder.fromUriString("http://example.com").path("/{foo}").query("bar={baz}").build();
-		UriComponents uriComponents3 = UriComponentsBuilder.fromUriString("http://example.com").path("/{foo}").query("bin={baz}").build();
+		UriComponents uriComponents1 = UriComponentsBuilder.fromUriString("https://example.com").path("/{foo}").query("bar={baz}").build();
+		UriComponents uriComponents2 = UriComponentsBuilder.fromUriString("https://example.com").path("/{foo}").query("bar={baz}").build();
+		UriComponents uriComponents3 = UriComponentsBuilder.fromUriString("https://example.com").path("/{foo}").query("bin={baz}").build();
 		assertThat(uriComponents1, instanceOf(HierarchicalUriComponents.class));
 		assertThat(uriComponents1, equalTo(uriComponents1));
 		assertThat(uriComponents1, equalTo(uriComponents2));

--- a/test/spring-android-rest-template-test/src/main/java/org/springframework/web/util/UriTemplateTests.java
+++ b/test/spring-android-rest-template-test/src/main/java/org/springframework/web/util/UriTemplateTests.java
@@ -35,22 +35,22 @@ public class UriTemplateTests extends TestCase {
 
 	@SmallTest
 	public void testGetVariableNames() throws Exception {
-		UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
+		UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
 		List<String> variableNames = template.getVariableNames();
 		assertEquals("Invalid variable names", Arrays.asList("hotel", "booking"), variableNames);
 	}
 
 	@SmallTest
 	public void testExpandVarArgs() throws Exception {
-		UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
+		UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
 		URI result = template.expand("1", "42");
-		assertEquals("Invalid expanded template", new URI("http://example.com/hotels/1/bookings/42"), result);
+		assertEquals("Invalid expanded template", new URI("https://example.com/hotels/1/bookings/42"), result);
 	}
 
 	@SmallTest
 	public void testExpandVarArgsNotEnoughVariables() throws Exception {
 		try {
-			UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
+			UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
 			template.expand("1");
 			fail("Expected IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
@@ -62,9 +62,9 @@ public class UriTemplateTests extends TestCase {
 		Map<String, String> uriVariables = new HashMap<String, String>(2);
 		uriVariables.put("booking", "42");
 		uriVariables.put("hotel", "1");
-		UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
+		UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
 		URI result = template.expand(uriVariables);
-		assertEquals("Invalid expanded template", new URI("http://example.com/hotels/1/bookings/42"), result);
+		assertEquals("Invalid expanded template", new URI("https://example.com/hotels/1/bookings/42"), result);
 	}
 
 	@SmallTest
@@ -80,17 +80,17 @@ public class UriTemplateTests extends TestCase {
 		Map<String, Integer> uriVariables = new HashMap<String, Integer>(2);
 		uriVariables.put("booking", 42);
 		uriVariables.put("hotel", 1);
-		UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
+		UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
 		URI result = template.expand(uriVariables);
-		assertEquals("Invalid expanded template", new URI("http://example.com/hotels/1/bookings/42"), result);
+		assertEquals("Invalid expanded template", new URI("https://example.com/hotels/1/bookings/42"), result);
 	}
 
 	@SmallTest
 	public void testExpandMapEncoded() throws Exception {
 		Map<String, String> uriVariables = Collections.singletonMap("hotel", "Z\u00fcrich");
-		UriTemplate template = new UriTemplate("http://example.com/hotel list/{hotel}");
+		UriTemplate template = new UriTemplate("https://example.com/hotel list/{hotel}");
 		URI result = template.expand(uriVariables);
-		assertEquals("Invalid expanded template", new URI("http://example.com/hotel%20list/Z%C3%BCrich"), result);
+		assertEquals("Invalid expanded template", new URI("https://example.com/hotel%20list/Z%C3%BCrich"), result);
 	}
 
 	@SmallTest
@@ -99,7 +99,7 @@ public class UriTemplateTests extends TestCase {
 			Map<String, String> uriVariables = new HashMap<String, String>(2);
 			uriVariables.put("booking", "42");
 			uriVariables.put("bar", "1");
-			UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
+			UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
 			template.expand(uriVariables);
 			fail("Expected IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
@@ -108,25 +108,25 @@ public class UriTemplateTests extends TestCase {
 
 	@SmallTest
 	public void testExpandEncoded() throws Exception {
-		UriTemplate template = new UriTemplate("http://example.com/hotel list/{hotel}");
+		UriTemplate template = new UriTemplate("https://example.com/hotel list/{hotel}");
 		URI result = template.expand("Z\u00fcrich");
-		assertEquals("Invalid expanded template", new URI("http://example.com/hotel%20list/Z%C3%BCrich"), result);
+		assertEquals("Invalid expanded template", new URI("https://example.com/hotel%20list/Z%C3%BCrich"), result);
 	}
 
 	@SmallTest
 	public void testMatches() throws Exception {
-		UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
-		assertTrue("UriTemplate does not match", template.matches("http://example.com/hotels/1/bookings/42"));
-		assertFalse("UriTemplate matches", template.matches("http://example.com/hotels/bookings"));
+		UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
+		assertTrue("UriTemplate does not match", template.matches("https://example.com/hotels/1/bookings/42"));
+		assertFalse("UriTemplate matches", template.matches("https://example.com/hotels/bookings"));
 		assertFalse("UriTemplate matches", template.matches(""));
 		assertFalse("UriTemplate matches", template.matches(null));
 	}
 
 	@SmallTest
 	public void testMatchesCustomRegex() throws Exception {
-		UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel:\\d+}");
-		assertTrue("UriTemplate does not match", template.matches("http://example.com/hotels/42"));
-		assertFalse("UriTemplate matches", template.matches("http://example.com/hotels/foo"));
+		UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel:\\d+}");
+		assertTrue("UriTemplate does not match", template.matches("https://example.com/hotels/42"));
+		assertFalse("UriTemplate matches", template.matches("https://example.com/hotels/foo"));
 	}
 
 	@SmallTest
@@ -135,8 +135,8 @@ public class UriTemplateTests extends TestCase {
 		expected.put("booking", "42");
 		expected.put("hotel", "1");
 
-		UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel}/bookings/{booking}");
-		Map<String, String> result = template.match("http://example.com/hotels/1/bookings/42");
+		UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel}/bookings/{booking}");
+		Map<String, String> result = template.match("https://example.com/hotels/1/bookings/42");
 		assertEquals("Invalid match", expected, result);
 	}
 
@@ -146,8 +146,8 @@ public class UriTemplateTests extends TestCase {
 		expected.put("booking", "42");
 		expected.put("hotel", "1");
 
-		UriTemplate template = new UriTemplate("http://example.com/hotels/{hotel:\\d}/bookings/{booking:\\d+}");
-		Map<String, String> result = template.match("http://example.com/hotels/1/bookings/42");
+		UriTemplate template = new UriTemplate("https://example.com/hotels/{hotel:\\d}/bookings/{booking:\\d+}");
+		Map<String, String> result = template.match("https://example.com/hotels/1/bookings/42");
 		assertEquals("Invalid match", expected, result);
 	}
 

--- a/test/spring-android-rest-template-test/src/main/java/org/springframework/web/util/UriUtilsTests.java
+++ b/test/spring-android-rest-template-test/src/main/java/org/springframework/web/util/UriUtilsTests.java
@@ -110,53 +110,53 @@ public class UriUtilsTests extends TestCase {
 	@SmallTest
 	@Deprecated
 	public void testEncodeUri() throws UnsupportedEncodingException {
-		assertEquals("Invalid encoded URI", "http://www.ietf.org/rfc/rfc3986.txt",
-				UriUtils.encodeUri("http://www.ietf.org/rfc/rfc3986.txt", ENC));
 		assertEquals("Invalid encoded URI", "https://www.ietf.org/rfc/rfc3986.txt",
 				UriUtils.encodeUri("https://www.ietf.org/rfc/rfc3986.txt", ENC));
-		assertEquals("Invalid encoded URI", "http://www.google.com/?q=Z%C3%BCrich",
-				UriUtils.encodeUri("http://www.google.com/?q=Z\u00fcrich", ENC));
+		assertEquals("Invalid encoded URI", "https://www.ietf.org/rfc/rfc3986.txt",
+				UriUtils.encodeUri("https://www.ietf.org/rfc/rfc3986.txt", ENC));
+		assertEquals("Invalid encoded URI", "https://www.google.com/?q=Z%C3%BCrich",
+				UriUtils.encodeUri("https://www.google.com/?q=Z\u00fcrich", ENC));
 		assertEquals("Invalid encoded URI",
-				"http://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar#and(java.util.BitSet)",
+				"https://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar#and(java.util.BitSet)",
 				UriUtils.encodeUri(
-						"http://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar#and(java.util.BitSet)",
+						"https://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar#and(java.util.BitSet)",
 						ENC));
-		assertEquals("Invalid encoded URI", "http://java.sun.com/j2se/1.3/",
-				UriUtils.encodeUri("http://java.sun.com/j2se/1.3/", ENC));
+		assertEquals("Invalid encoded URI", "https://java.sun.com/j2se/1.3/",
+				UriUtils.encodeUri("https://java.sun.com/j2se/1.3/", ENC));
 		assertEquals("Invalid encoded URI", "docs/guide/collections/designfaq.html#28",
 				UriUtils.encodeUri("docs/guide/collections/designfaq.html#28", ENC));
 		assertEquals("Invalid encoded URI", "../../../demo/jfc/SwingSet2/src/SwingSet2.java",
 				UriUtils.encodeUri("../../../demo/jfc/SwingSet2/src/SwingSet2.java", ENC));
 		assertEquals("Invalid encoded URI", "file:///~/calendar", UriUtils.encodeUri("file:///~/calendar", ENC));
-		assertEquals("Invalid encoded URI", "http://example.com/query=foo@bar",
-				UriUtils.encodeUri("http://example.com/query=foo@bar", ENC));
+		assertEquals("Invalid encoded URI", "https://example.com/query=foo@bar",
+				UriUtils.encodeUri("https://example.com/query=foo@bar", ENC));
 
 		// SPR-8974
-		assertEquals("http://example.org?format=json&url=http://another.com?foo=bar",
-				UriUtils.encodeUri("http://example.org?format=json&url=http://another.com?foo=bar", ENC));
+		assertEquals("https://example.org?format=json&url=http://another.com?foo=bar",
+				UriUtils.encodeUri("https://example.org?format=json&url=http://another.com?foo=bar", ENC));
 	}
 
 	@SmallTest
 	@Deprecated
 	public void testEncodeHttpUrl() throws UnsupportedEncodingException {
-		assertEquals("Invalid encoded HTTP URL", "http://www.ietf.org/rfc/rfc3986.txt",
-				UriUtils.encodeHttpUrl("http://www.ietf.org/rfc/rfc3986.txt", ENC));
+		assertEquals("Invalid encoded HTTP URL", "https://www.ietf.org/rfc/rfc3986.txt",
+				UriUtils.encodeHttpUrl("https://www.ietf.org/rfc/rfc3986.txt", ENC));
 		assertEquals("Invalid encoded URI", "https://www.ietf.org/rfc/rfc3986.txt",
 				UriUtils.encodeHttpUrl("https://www.ietf.org/rfc/rfc3986.txt", ENC));
-		assertEquals("Invalid encoded HTTP URL", "http://www.google.com/?q=Z%C3%BCrich",
-				UriUtils.encodeHttpUrl("http://www.google.com/?q=Z\u00fcrich", ENC));
-		assertEquals("Invalid encoded HTTP URL", "http://ws.geonames.org/searchJSON?q=T%C5%8Dky%C5%8D&style=FULL&maxRows=300",
-				UriUtils.encodeHttpUrl("http://ws.geonames.org/searchJSON?q=T\u014dky\u014d&style=FULL&maxRows=300", ENC));
+		assertEquals("Invalid encoded HTTP URL", "https://www.google.com/?q=Z%C3%BCrich",
+				UriUtils.encodeHttpUrl("https://www.google.com/?q=Z\u00fcrich", ENC));
+		assertEquals("Invalid encoded HTTP URL", "https://ws.geonames.org/searchJSON?q=T%C5%8Dky%C5%8D&style=FULL&maxRows=300",
+				UriUtils.encodeHttpUrl("https://ws.geonames.org/searchJSON?q=T\u014dky\u014d&style=FULL&maxRows=300", ENC));
 		assertEquals("Invalid encoded HTTP URL",
-				"http://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar",
+				"https://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar",
 				UriUtils.encodeHttpUrl(
-						"http://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar", ENC));
-		assertEquals("Invalid encoded HTTP URL", "http://search.twitter.com/search.atom?q=%23avatar",
-				UriUtils.encodeHttpUrl("http://search.twitter.com/search.atom?q=#avatar", ENC));
-		assertEquals("Invalid encoded HTTP URL", "http://java.sun.com/j2se/1.3/",
-				UriUtils.encodeHttpUrl("http://java.sun.com/j2se/1.3/", ENC));
-		assertEquals("Invalid encoded HTTP URL", "http://example.com/query=foo@bar",
-				UriUtils.encodeHttpUrl("http://example.com/query=foo@bar", ENC));
+						"https://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar", ENC));
+		assertEquals("Invalid encoded HTTP URL", "https://search.twitter.com/search.atom?q=%23avatar",
+				UriUtils.encodeHttpUrl("https://search.twitter.com/search.atom?q=#avatar", ENC));
+		assertEquals("Invalid encoded HTTP URL", "https://java.sun.com/j2se/1.3/",
+				UriUtils.encodeHttpUrl("https://java.sun.com/j2se/1.3/", ENC));
+		assertEquals("Invalid encoded HTTP URL", "https://example.com/query=foo@bar",
+				UriUtils.encodeHttpUrl("https://example.com/query=foo@bar", ENC));
 	}
 
 	@SmallTest


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://tools.android.com/tech-docs/new-build-system/user-guide (200) with 1 occurrences could not be migrated:  
   ([https](https://tools.android.com/tech-docs/new-build-system/user-guide) result ClosedChannelException).
* [ ] http://xml.org/sax/features/external-general-entities (301) with 1 occurrences could not be migrated:  
   ([https](https://xml.org/sax/features/external-general-entities) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://bugs.sun.com/view_bug.do?bug_id=6342411 (302) with 1 occurrences migrated to:  
  https://bugs.java.com/view_bug.do?bug_id=6342411 ([https](https://bugs.sun.com/view_bug.do?bug_id=6342411) result SSLHandshakeException).
* [ ] http://192.168.28.42/1.jsp (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.28.42/1.jsp ([https](https://192.168.28.42/1.jsp) result ConnectTimeoutException).
* [ ] http://example.com:8080/bar (ConnectTimeoutException) with 5 occurrences migrated to:  
  https://example.com:8080/bar ([https](https://example.com:8080/bar) result ConnectTimeoutException).
* [ ] http://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar (UnknownHostException) with 5 occurrences migrated to:  
  https://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar ([https](https://arjen:foobar@java.sun.com:80/javase/6/docs/api/java/util/BitSet.html?foo=bar) result UnknownHostException).
* [ ] http://example.com&quot;,HttpMethod.GET (UnknownHostException) with 3 occurrences migrated to:  
  https://example.com&quot;,HttpMethod.GET ([https](https://example.com&quot;,HttpMethod.GET) result UnknownHostException).
* [ ] http://springone2gx.com (UnknownHostException) with 1 occurrences migrated to:  
  https://springone2gx.com ([https](https://springone2gx.com) result UnknownHostException).
* [ ] http://wiki.fasterxml.com/JacksonHome (UnknownHostException) with 1 occurrences migrated to:  
  https://wiki.fasterxml.com/JacksonHome ([https](https://wiki.fasterxml.com/JacksonHome) result UnknownHostException).
* [ ] http://ws.geonames.org/searchJSON?q=T (UnknownHostException) with 1 occurrences migrated to:  
  https://ws.geonames.org/searchJSON?q=T ([https](https://ws.geonames.org/searchJSON?q=T) result UnknownHostException).
* [ ] http://ws.geonames.org/searchJSON?q=T%C5%8Dky%C5%8D&style=FULL&maxRows=300 (UnknownHostException) with 1 occurrences migrated to:  
  https://ws.geonames.org/searchJSON?q=T%C5%8Dky%C5%8D&style=FULL&maxRows=300 ([https](https://ws.geonames.org/searchJSON?q=T%C5%8Dky%C5%8D&style=FULL&maxRows=300) result UnknownHostException).
* [ ] http://bitworking.org/projects/URI-Templates/ (302) with 1 occurrences migrated to:  
  https://bitworking.org/projects/URI-Templates/ ([https](https://bitworking.org/projects/URI-Templates/) result 404).
* [ ] http://help.github.com/send-pull-requests (404) with 1 occurrences migrated to:  
  https://help.github.com/send-pull-requests ([https](https://help.github.com/send-pull-requests) result 404).
* [ ] http://twitter.com/kdonald/a_new_picture (301) with 4 occurrences migrated to:  
  https://twitter.com/kdonald/a_new_picture ([https](https://twitter.com/kdonald/a_new_picture) result 404).
* [ ] http://search.twitter.com/search.atom?q= (410) with 1 occurrences migrated to:  
  https://search.twitter.com/search.atom?q= ([https](https://search.twitter.com/search.atom?q=) result 410).
* [ ] http://search.twitter.com/search.atom?q=%23avatar (410) with 1 occurrences migrated to:  
  https://search.twitter.com/search.atom?q=%23avatar ([https](https://search.twitter.com/search.atom?q=%23avatar) result 410).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://developer.android.com with 1 occurrences migrated to:  
  https://developer.android.com ([https](https://developer.android.com) result 200).
* [ ] http://en.wikipedia.org/wiki/List_of_HTTP_status_codes with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/List_of_HTTP_status_codes ([https](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) result 200).
* [ ] http://example.com with 56 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://example.com/ with 3 occurrences migrated to:  
  https://example.com/ ([https](https://example.com/) result 200).
* [ ] http://example.com/-foo with 2 occurrences migrated to:  
  https://example.com/-foo ([https](https://example.com/-foo) result 200).
* [ ] http://example.com/1 with 1 occurrences migrated to:  
  https://example.com/1 ([https](https://example.com/1) result 200).
* [ ] http://example.com/2 with 1 occurrences migrated to:  
  https://example.com/2 ([https](https://example.com/2) result 200).
* [ ] http://example.com/abc/ with 4 occurrences migrated to:  
  https://example.com/abc/ ([https](https://example.com/abc/) result 200).
* [ ] http://example.com/abc/x/y with 1 occurrences migrated to:  
  https://example.com/abc/x/y ([https](https://example.com/abc/x/y) result 200).
* [ ] http://example.com/abc/x/y/z with 3 occurrences migrated to:  
  https://example.com/abc/x/y/z ([https](https://example.com/abc/x/y/z) result 200).
* [ ] http://example.com/bar with 4 occurrences migrated to:  
  https://example.com/bar ([https](https://example.com/bar) result 200).
* [ ] http://example.com/foo with 2 occurrences migrated to:  
  https://example.com/foo ([https](https://example.com/foo) result 200).
* [ ] http://example.com/foo/../bar with 8 occurrences migrated to:  
  https://example.com/foo/../bar ([https](https://example.com/foo/../bar) result 200).
* [ ] http://example.com/foo/foo2?bar with 1 occurrences migrated to:  
  https://example.com/foo/foo2?bar ([https](https://example.com/foo/foo2?bar) result 200).
* [ ] http://example.com/foo?bar with 4 occurrences migrated to:  
  https://example.com/foo?bar ([https](https://example.com/foo?bar) result 200).
* [ ] http://example.com/foo?bar= with 2 occurrences migrated to:  
  https://example.com/foo?bar= ([https](https://example.com/foo?bar=) result 200).
* [ ] http://example.com/foo?bar=baz with 2 occurrences migrated to:  
  https://example.com/foo?bar=baz ([https](https://example.com/foo?bar=baz) result 200).
* [ ] http://example.com/foo?baz=42 with 1 occurrences migrated to:  
  https://example.com/foo?baz=42 ([https](https://example.com/foo?baz=42) result 200).
* [ ] http://example.com/foo?foo=bar&baz=qux with 2 occurrences migrated to:  
  https://example.com/foo?foo=bar&baz=qux ([https](https://example.com/foo?foo=bar&baz=qux) result 200).
* [ ] http://example.com/hotel with 5 occurrences migrated to:  
  https://example.com/hotel ([https](https://example.com/hotel) result 200).
* [ ] http://example.com/hotel%20list with 2 occurrences migrated to:  
  https://example.com/hotel%20list ([https](https://example.com/hotel%20list) result 200).
* [ ] http://example.com/hotel%20list/Z with 1 occurrences migrated to:  
  https://example.com/hotel%20list/Z ([https](https://example.com/hotel%20list/Z) result 200).
* [ ] http://example.com/hotel%20list/Z%C3%BCrich with 5 occurrences migrated to:  
  https://example.com/hotel%20list/Z%C3%BCrich ([https](https://example.com/hotel%20list/Z%C3%BCrich) result 200).
* [ ] http://example.com/hotel%2520list with 1 occurrences migrated to:  
  https://example.com/hotel%2520list ([https](https://example.com/hotel%2520list) result 200).
* [ ] http://example.com/hotels with 3 occurrences migrated to:  
  https://example.com/hotels ([https](https://example.com/hotels) result 200).
* [ ] http://example.com/hotels/ with 17 occurrences migrated to:  
  https://example.com/hotels/ ([https](https://example.com/hotels/) result 200).
* [ ] http://example.com/hotels/1/bookings/42 with 7 occurrences migrated to:  
  https://example.com/hotels/1/bookings/42 ([https](https://example.com/hotels/1/bookings/42) result 200).
* [ ] http://example.com/hotels/42 with 1 occurrences migrated to:  
  https://example.com/hotels/42 ([https](https://example.com/hotels/42) result 200).
* [ ] http://example.com/hotels/42/bookings/21 with 2 occurrences migrated to:  
  https://example.com/hotels/42/bookings/21 ([https](https://example.com/hotels/42/bookings/21) result 200).
* [ ] http://example.com/hotels/42/bookings/42 with 1 occurrences migrated to:  
  https://example.com/hotels/42/bookings/42 ([https](https://example.com/hotels/42/bookings/42) result 200).
* [ ] http://example.com/hotels/42/rooms/42 with 1 occurrences migrated to:  
  https://example.com/hotels/42/rooms/42 ([https](https://example.com/hotels/42/rooms/42) result 200).
* [ ] http://example.com/hotels/Rest%20%26%20Relax/bookings/42 with 2 occurrences migrated to:  
  https://example.com/hotels/Rest%20%26%20Relax/bookings/42 ([https](https://example.com/hotels/Rest%20%26%20Relax/bookings/42) result 200).
* [ ] http://example.com/hotels/bookings with 1 occurrences migrated to:  
  https://example.com/hotels/bookings ([https](https://example.com/hotels/bookings) result 200).
* [ ] http://example.com/hotels/foo with 1 occurrences migrated to:  
  https://example.com/hotels/foo ([https](https://example.com/hotels/foo) result 200).
* [ ] http://example.com/myFileUpload with 1 occurrences migrated to:  
  https://example.com/myFileUpload ([https](https://example.com/myFileUpload) result 200).
* [ ] http://example.com/myForm with 1 occurrences migrated to:  
  https://example.com/myForm ([https](https://example.com/myForm) result 200).
* [ ] http://example.com/query=foo@bar with 4 occurrences migrated to:  
  https://example.com/query=foo@bar ([https](https://example.com/query=foo@bar) result 200).
* [ ] http://example.com/resource with 3 occurrences migrated to:  
  https://example.com/resource ([https](https://example.com/resource) result 200).
* [ ] http://example.com?foo=bar@baz with 1 occurrences migrated to:  
  https://example.com?foo=bar@baz ([https](https://example.com?foo=bar@baz) result 200).
* [ ] http://example.org?format=json&url=http://another.com?foo=bar with 2 occurrences migrated to:  
  https://example.org?format=json&url=http://another.com?foo=bar ([https](https://example.org?format=json&url=https://another.com?foo=bar) result 200).
* [ ] http://git-scm.com with 1 occurrences migrated to:  
  https://git-scm.com ([https](https://git-scm.com) result 200).
* [ ] http://hc.apache.org/httpcomponents-client-ga/httpclient/ with 1 occurrences migrated to:  
  https://hc.apache.org/httpcomponents-client-ga/httpclient/ ([https](https://hc.apache.org/httpcomponents-client-ga/httpclient/) result 200).
* [ ] http://jira.spring.io/browse/ANDROID with 1 occurrences migrated to:  
  https://jira.spring.io/browse/ANDROID ([https](https://jira.spring.io/browse/ANDROID) result 200).
* [ ] http://maven.apache.org with 1 occurrences migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* [ ] http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* [ ] http://spring.io/ with 1 occurrences migrated to:  
  https://spring.io/ ([https](https://spring.io/) result 200).
* [ ] http://spring.io/blog/ with 1 occurrences migrated to:  
  https://spring.io/blog/ ([https](https://spring.io/blog/) result 200).
* [ ] http://spring.io/blog/category/news with 1 occurrences migrated to:  
  https://spring.io/blog/category/news ([https](https://spring.io/blog/category/news) result 200).
* [ ] http://spring.io/guides with 1 occurrences migrated to:  
  https://spring.io/guides ([https](https://spring.io/guides) result 200).
* [ ] http://spring.io/services with 1 occurrences migrated to:  
  https://spring.io/services ([https](https://spring.io/services) result 200).
* [ ] http://square.github.io/okhttp/ with 2 occurrences migrated to:  
  https://square.github.io/okhttp/ ([https](https://square.github.io/okhttp/) result 200).
* [ ] http://stackoverflow.com/faq with 1 occurrences migrated to:  
  https://stackoverflow.com/faq ([https](https://stackoverflow.com/faq) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-android with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-android ([https](https://stackoverflow.com/questions/tagged/spring-android) result 200).
* [ ] http://stas-blogspot.blogspot.com/2010/03/java-bridge-methods-explained.html with 1 occurrences migrated to:  
  https://stas-blogspot.blogspot.com/2010/03/java-bridge-methods-explained.html ([https](https://stas-blogspot.blogspot.com/2010/03/java-bridge-methods-explained.html) result 200).
* [ ] http://tools.ietf.org/html/rfc1945 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc1945 ([https](https://tools.ietf.org/html/rfc1945) result 200).
* [ ] http://tools.ietf.org/html/rfc2109 with 2 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2109 ([https](https://tools.ietf.org/html/rfc2109) result 200).
* [ ] http://tools.ietf.org/html/rfc2295 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2295 ([https](https://tools.ietf.org/html/rfc2295) result 200).
* [ ] http://tools.ietf.org/html/rfc2324 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2324 ([https](https://tools.ietf.org/html/rfc2324) result 200).
* [ ] http://tools.ietf.org/html/rfc2518 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2518 ([https](https://tools.ietf.org/html/rfc2518) result 200).
* [ ] http://tools.ietf.org/html/rfc2616 with 6 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2616 ([https](https://tools.ietf.org/html/rfc2616) result 200).
* [ ] http://tools.ietf.org/html/rfc2774 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2774 ([https](https://tools.ietf.org/html/rfc2774) result 200).
* [ ] http://tools.ietf.org/html/rfc2817 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2817 ([https](https://tools.ietf.org/html/rfc2817) result 200).
* [ ] http://tools.ietf.org/html/rfc2965 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc2965 ([https](https://tools.ietf.org/html/rfc2965) result 200).
* [ ] http://tools.ietf.org/html/rfc3229 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc3229 ([https](https://tools.ietf.org/html/rfc3229) result 200).
* [ ] http://tools.ietf.org/html/rfc3986 with 2 occurrences migrated to:  
  https://tools.ietf.org/html/rfc3986 ([https](https://tools.ietf.org/html/rfc3986) result 200).
* [ ] http://tools.ietf.org/html/rfc4918 with 5 occurrences migrated to:  
  https://tools.ietf.org/html/rfc4918 ([https](https://tools.ietf.org/html/rfc4918) result 200).
* [ ] http://tools.ietf.org/html/rfc5842 with 2 occurrences migrated to:  
  https://tools.ietf.org/html/rfc5842 ([https](https://tools.ietf.org/html/rfc5842) result 200).
* [ ] http://tools.ietf.org/html/rfc5988 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc5988 ([https](https://tools.ietf.org/html/rfc5988) result 200).
* [ ] http://tools.ietf.org/html/rfc6266 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6266 ([https](https://tools.ietf.org/html/rfc6266) result 200).
* [ ] http://tools.ietf.org/html/rfc6454 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6454 ([https](https://tools.ietf.org/html/rfc6454) result 200).
* [ ] http://tools.ietf.org/html/rfc6585 with 4 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6585 ([https](https://tools.ietf.org/html/rfc6585) result 200).
* [ ] http://tools.ietf.org/html/rfc7230 with 8 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7230 ([https](https://tools.ietf.org/html/rfc7230) result 200).
* [ ] http://tools.ietf.org/html/rfc7231 with 53 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7231 ([https](https://tools.ietf.org/html/rfc7231) result 200).
* [ ] http://tools.ietf.org/html/rfc7232 with 8 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7232 ([https](https://tools.ietf.org/html/rfc7232) result 200).
* [ ] http://tools.ietf.org/html/rfc7233 with 6 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7233 ([https](https://tools.ietf.org/html/rfc7233) result 200).
* [ ] http://tools.ietf.org/html/rfc7234 with 5 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7234 ([https](https://tools.ietf.org/html/rfc7234) result 200).
* [ ] http://tools.ietf.org/html/rfc7235 with 6 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7235 ([https](https://tools.ietf.org/html/rfc7235) result 200).
* [ ] http://tools.ietf.org/html/rfc7238 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc7238 ([https](https://tools.ietf.org/html/rfc7238) result 200).
* [ ] http://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt with 3 occurrences migrated to:  
  https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt ([https](https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-ietf-webdav-protocol-06.txt) result 200).
* [ ] http://twitter.com/kdonald with 3 occurrences migrated to:  
  https://twitter.com/kdonald ([https](https://twitter.com/kdonald) result 200).
* [ ] http://www.example.com/hotels with 2 occurrences migrated to:  
  https://www.example.com/hotels ([https](https://www.example.com/hotels) result 200).
* [ ] http://www.example.org/?param=aGVsbG9Xb3JsZA%3D%3D with 1 occurrences migrated to:  
  https://www.example.org/?param=aGVsbG9Xb3JsZA%3D%3D ([https](https://www.example.org/?param=aGVsbG9Xb3JsZA%3D%3D) result 200).
* [ ] http://www.google.com/?q=Z with 2 occurrences migrated to:  
  https://www.google.com/?q=Z ([https](https://www.google.com/?q=Z) result 200).
* [ ] http://www.google.com/?q=Z%C3%BCrich with 2 occurrences migrated to:  
  https://www.google.com/?q=Z%C3%BCrich ([https](https://www.google.com/?q=Z%C3%BCrich) result 200).
* [ ] http://www.google.com/ig/calculator?q=1USD=?EUR with 1 occurrences migrated to:  
  https://www.google.com/ig/calculator?q=1USD=?EUR ([https](https://www.google.com/ig/calculator?q=1USD=?EUR) result 200).
* [ ] http://www.ietf.org with 1 occurrences migrated to:  
  https://www.ietf.org ([https](https://www.ietf.org) result 200).
* [ ] http://www.ietf.org/rfc/rfc2396.txt with 2 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2396.txt ([https](https://www.ietf.org/rfc/rfc2396.txt) result 200).
* [ ] http://www.ietf.org/rfc/rfc2617.txt with 2 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc2617.txt ([https](https://www.ietf.org/rfc/rfc2617.txt) result 200).
* [ ] http://www.ietf.org/rfc/rfc3986.txt with 15 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc3986.txt ([https](https://www.ietf.org/rfc/rfc3986.txt) result 200).
* [ ] http://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal with 1 occurrences migrated to:  
  https://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal ([https](https://code.google.com/p/gears/wiki/ResumableHttpRequestsProposal) result 301).
* [ ] http://code.google.com/p/maven-android-plugin with 1 occurrences migrated to:  
  https://code.google.com/p/maven-android-plugin ([https](https://code.google.com/p/maven-android-plugin) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring-android/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-android/docs/current/api/ ([https](https://docs.spring.io/spring-android/docs/current/api/) result 301).
* [ ] http://docs.spring.io/spring-android/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-android/docs/current/reference/html/ ([https](https://docs.spring.io/spring-android/docs/current/reference/html/) result 301).
* [ ] http://facebook.com/keith.donald with 3 occurrences migrated to:  
  https://facebook.com/keith.donald ([https](https://facebook.com/keith.donald) result 301).
* [ ] http://facebook.com/keith.donald/picture with 3 occurrences migrated to:  
  https://facebook.com/keith.donald/picture ([https](https://facebook.com/keith.donald/picture) result 301).
* [ ] http://help.github.com/fork-a-repo/ with 2 occurrences migrated to:  
  https://help.github.com/fork-a-repo/ ([https](https://help.github.com/fork-a-repo/) result 301).
* [ ] http://help.github.com/send-pull-requests/ with 2 occurrences migrated to:  
  https://help.github.com/send-pull-requests/ ([https](https://help.github.com/send-pull-requests/) result 301).
* [ ] http://jakarta.apache.org/commons/lang/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/lang/ ([https](https://jakarta.apache.org/commons/lang/) result 301).
* [ ] http://mac.github.com with 1 occurrences migrated to:  
  https://mac.github.com ([https](https://mac.github.com) result 301).
* [ ] http://projects.spring.io/spring-android with 1 occurrences migrated to:  
  https://projects.spring.io/spring-android ([https](https://projects.spring.io/spring-android) result 301).
* [ ] http://twitter.com/kdonald/picture with 3 occurrences migrated to:  
  https://twitter.com/kdonald/picture ([https](https://twitter.com/kdonald/picture) result 301).
* [ ] http://windows.github.com with 1 occurrences migrated to:  
  https://windows.github.com ([https](https://windows.github.com) result 301).
* [ ] http://www.gradle.org with 1 occurrences migrated to:  
  https://www.gradle.org ([https](https://www.gradle.org) result 301).
* [ ] http://www.spring.io/projects/spring-android with 1 occurrences migrated to:  
  https://www.spring.io/projects/spring-android ([https](https://www.spring.io/projects/spring-android) result 301).
* [ ] http://www.spring.io/projects/spring-framework with 1 occurrences migrated to:  
  https://www.spring.io/projects/spring-framework ([https](https://www.spring.io/projects/spring-framework) result 301).
* [ ] http://www.spring.io/sts with 1 occurrences migrated to:  
  https://www.spring.io/sts ([https](https://www.spring.io/sts) result 301).
* [ ] http://gafter.blogspot.nl/2006/12/super-type-tokens.html with 1 occurrences migrated to:  
  https://gafter.blogspot.nl/2006/12/super-type-tokens.html ([https](https://gafter.blogspot.nl/2006/12/super-type-tokens.html) result 302).
* [ ] http://java.sun.com/docs/books/jls/third_edition/html/expressions.html with 1 occurrences migrated to:  
  https://java.sun.com/docs/books/jls/third_edition/html/expressions.html ([https](https://java.sun.com/docs/books/jls/third_edition/html/expressions.html) result 302).
* [ ] http://java.sun.com/j2se/1.3/ with 4 occurrences migrated to:  
  https://java.sun.com/j2se/1.3/ ([https](https://java.sun.com/j2se/1.3/) result 302).
* [ ] http://www.iana.org/assignments/http-status-codes with 1 occurrences migrated to:  
  https://www.iana.org/assignments/http-status-codes ([https](https://www.iana.org/assignments/http-status-codes) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 2 occurrences
* http://localhost/query= with 1 occurrences
* http://localhost/query=foo@bar with 1 occurrences